### PR TITLE
Support BMGHK inputs in the decoder kernel

### DIFF
--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -98,8 +98,8 @@ class AttentionDecodingFlashDecoding:
             print(f"Runtime error: {e}")
 
 
-class AttentionDecodingSplitKV(AttentionDecodingFlashDecoding):
-    OP = xops.fmha.triton_splitk.FwOp
+# class AttentionDecodingSplitKV(AttentionDecodingFlashDecoding):
+#     OP = xops.fmha.triton_splitk.FwOp
 
 
 class AttentionDecodingCK(AttentionDecodingFlashDecoding):

--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -17,13 +17,9 @@ device = torch.device("cuda")
 
 
 CASES = [
-    dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=1, K=128)
-    for i in range(8, 18)
+    dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=hkv, K=128)
+    for i in range(8, 18) for hkv in (1, 2)
 ]
-# + [
-#     dict(B=max(1, 2 ** (16 - i)), Mq=1, Mkv=2**i, Hq=16, Hkv=2, K=128)
-#     for i in range(8, 18)
-# ]
 
 
 def _setup_test(
@@ -98,21 +94,19 @@ class AttentionDecodingFlashDecoding:
     def fw(self) -> None:
         try:
             xops.memory_efficient_attention_forward(self.q, self.k, self.v, op=self.OP)
-        except RuntimeError as e:
+        except (RuntimeError, ValueError) as e:
             print(f"Runtime error: {e}")
 
 
-# class AttentionDecodingSplitKV(AttentionDecodingFlashDecoding):
-#     OP = xops.fmha.triton_splitk.FwOp
+class AttentionDecodingSplitKV(AttentionDecodingFlashDecoding):
+    OP = xops.fmha.triton_splitk.FwOp
 
 
 class AttentionDecodingCK(AttentionDecodingFlashDecoding):
-
     OP = xops.fmha.ck.FwOp
 
 
 class AttentionDecodingCKDecoder(AttentionDecodingFlashDecoding):
-
     OP = xops.fmha.ck_decoder.FwOp
 
 

--- a/xformers/csrc/attention/hip_fmha/attention_forward_decoder.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_decoder.cpp
@@ -258,15 +258,15 @@ int main(int argc, char** argv)
                       << std::endl;
             return 0;
         }
-        const int32_t n_keys                 = std::stoi(args[0]);
-        const int32_t padding                = std::stoi(args[1]);
-        const int32_t batch_size             = std::stoi(args[2]);
-        const int32_t n_heads                = std::stoi(args[3]);
-        const int32_t n_groups               = 1;
-        const int32_t multiquery             = (args[4] == "mq");
-        const auto dtype                     = (args[5] == "f32")   ? torch::kFloat32
-                                               : (args[5] == "f16") ? torch::kFloat16
-                                                                    : torch::kBFloat16;
+        const int32_t n_keys     = std::stoi(args[0]);
+        const int32_t padding    = std::stoi(args[1]);
+        const int32_t batch_size = std::stoi(args[2]);
+        const int32_t n_heads    = std::stoi(args[3]);
+        const int32_t n_groups   = 1;
+        const int32_t multiquery = (args[4] == "mq");
+        const auto dtype         = (args[5] == "f32")
+                               ? torch::kFloat32
+                               : (args[5] == "f16") ? torch::kFloat16 : torch::kBFloat16;
         const int32_t n_wavefronts_per_block = std::stoi(args[6]);
 
         const int32_t dim_per_head = 4 * kThreadsPerWavefront;

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
@@ -528,11 +528,11 @@ struct FMHADecoderSeqlen1DeviceOp : public BaseOperator
                 stream_config,
                 Q_size_k_alignment_necessary == 4
                     ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 4>
-                : Q_size_k_alignment_necessary == 2
-                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 2>
-                : Q_size_k_alignment_necessary == 1
-                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 1>
-                    : nullptr,
+                    : Q_size_k_alignment_necessary == 2
+                          ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 2>
+                          : Q_size_k_alignment_necessary == 1
+                                ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 1>
+                                : nullptr,
                 arg.grid_dim,
                 arg.block_dim,
                 arg.lds_bytes,

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
@@ -114,27 +114,29 @@ efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
                                               const scalar_t* __restrict__ cache_V,
                                               scalar_t* __restrict__ O,
                                               const int32_t* __restrict__ seq_kv_lens,
-                                              const ptrdiff_t XQ_stride_0,
-                                              const ptrdiff_t XQ_stride_1,
-                                              const ptrdiff_t XQ_stride_2,
-                                              const ptrdiff_t K_stride_0,
-                                              const ptrdiff_t K_stride_1,
-                                              const ptrdiff_t K_stride_2,
-                                              const int32_t K_size_1,
-                                              const int32_t D_H,
+                                              const ptrdiff_t XQ_stride_b,
+                                              const ptrdiff_t XQ_stride_m,
+                                              const ptrdiff_t XQ_stride_h,
+                                              const ptrdiff_t K_stride_b,
+                                              const ptrdiff_t K_stride_m,
+                                              const ptrdiff_t K_stride_h,
+                                              const int32_t Q_size_m,
+                                              const int32_t Q_size_h,
+                                              const int32_t Q_size_k,
+                                              const int32_t K_size_m,
                                               const bool multiquery,
                                               const float qk_scale)
 {
     static_assert(n_loop_unroll_tail < n_loop_unroll, "");
 
     // Each block handles a single batch and head and query
-    const int32_t b = blockIdx.x;
-    const int32_t h = blockIdx.y;
-    const int32_t m = blockIdx.z;
+    const int32_t b = blockIdx.x / (Q_size_m * Q_size_h);
+    const int32_t h = (blockIdx.x / Q_size_m) % Q_size_h;
+    const int32_t m = blockIdx.x % Q_size_m;
 
     // Note: this is decoding case where we attend to current and all previous
     // tokens.
-    const int32_t t_max = seq_kv_lens ? seq_kv_lens[b] : K_size_1;
+    const int32_t t_max = seq_kv_lens ? seq_kv_lens[b] : K_size_m;
 
     const int32_t lane_idx              = threadIdx.x;
     const int32_t wavefront_idx         = threadIdx.y;
@@ -143,10 +145,10 @@ efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
     const int32_t threads_per_block     = threads_per_wavefront * wavefronts_per_block;
     const int32_t thread_linear_idx     = lane_idx + wavefront_idx * threads_per_wavefront;
     // const auto* q_ = &(XQ_acc[b][m][h][0]);
-    const auto XQO_base_offset  = b * XQ_stride_0 + m * XQ_stride_1 + h * XQ_stride_2;
+    const auto XQO_base_offset  = b * XQ_stride_b + m * XQ_stride_m + h * XQ_stride_h;
     const auto* __restrict__ q_ = XQ + XQO_base_offset;
 
-    const auto cache_KV_base_offset       = b * K_stride_0 + (multiquery ? 0 : h * K_stride_2);
+    const auto cache_KV_base_offset       = b * K_stride_b + (multiquery ? 0 : h * K_stride_h);
     const auto* __restrict__ cache_K_base = cache_K + cache_KV_base_offset;
     const auto* __restrict__ cache_V_base = cache_V + cache_KV_base_offset;
 
@@ -158,7 +160,7 @@ efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
     using compute_t     = float;
     using compute_vec_t = typename ck::vector_type<compute_t, vec_size>::type;
 
-    const bool lane_active_for_io = lane_idx * vec_size < D_H;
+    const bool lane_active_for_io = lane_idx * vec_size < Q_size_k;
 
     extern __shared__ __align__(16) compute_t smem[];
 
@@ -188,344 +190,276 @@ efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
             {
                 const int32_t t = tt + ttt;
                 // load the K[b][t][h|0][:] row into registers
-                load_v<data_t, data_vec_t>(cache_K_base + t * K_stride_1, lane_idx, &k_loads[ttt]);
+                load_v<data_t, data_vec_t>(cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
             }
         }
-        compute_t qk_accs[n_loop_unroll] = {};
-#pragma unroll n_loop_unroll
-        for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
-        {
-            ck::inner_product<data_vec_t, data_vec_t, compute_t>(
-                q_thread, k_loads[ttt], qk_accs[ttt]);
-            qk_accs[ttt] *= qk_scale;
+        // Each block computes different B value
+        compute_t max_qk_acc = ck::NumericLimits<compute_t>::Lowest();
 
-            qk_accs[ttt] = wavefrontReduce(qk_accs[ttt], [](auto a, auto b) { return a + b; });
-            max_qk_acc   = ck::math::max(qk_accs[ttt], max_qk_acc);
-        }
-        if(lane_idx == 0)
-        {
-            auto* __restrict__ smem_base = smem + tt;
-#pragma unroll n_loop_unroll
-            for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
-            {
-                smem_base[ttt] = qk_accs[ttt];
-            }
-        }
-    }
+        // Compute S[T_MAX] = for i in range(T): S[t] = sum(Q[d] * K[t, d])
+        // Split T across wavefronts in a block, unroll loads to expose more
+        // parallelism.
 
-    // NB: the length of the tail is <= (wavefronts_per_block * n_loop_unroll)
-    for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
-        tt += wavefronts_per_block * n_loop_unroll_tail)
-    {
-        if(lane_active_for_io)
-        {
-#pragma unroll n_loop_unroll_tail
-            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-            {
-                const int32_t t = tt + ttt;
-                if(t < t_max)
-                {
-                    // load the K[b][t][h|0][:] row into registers
-                    load_v<data_t, data_vec_t>(
-                        cache_K_base + t * K_stride_1, lane_idx, &k_loads[ttt]);
-                }
-            }
-        }
-#pragma unroll n_loop_unroll_tail
-        for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-        {
-            compute_t qk_acc = 0;
-            const int32_t t  = tt + ttt;
-            if(t < t_max)
-            {
-                ck::inner_product<data_vec_t, data_vec_t, compute_t>(
-                    q_thread, k_loads[ttt], qk_acc);
-                qk_acc *= qk_scale;
-
-                qk_acc     = wavefrontReduce(qk_acc, [](auto a, auto b) { return a + b; });
-                max_qk_acc = ck::math::max(qk_acc, max_qk_acc);
-
-                // write accumulated sums to smem.
-                if(lane_idx == 0)
-                {
-                    smem[t] = qk_acc;
-                }
-            }
-        }
-    }
-
-    // Use shared reduction to compute max and compute softmax on shared memory.
-    // write max acc
-    if(lane_idx == 0)
-    {
-        smem[T_MAX + wavefront_idx] = max_qk_acc;
-    }
-    __syncthreads();
-    if(lane_idx < wavefronts_per_block)
-    {
-        max_qk_acc = ck::math::max(max_qk_acc, smem[T_MAX + lane_idx]);
-    }
-    // shared across all threads in block
-    max_qk_acc = wavefrontReduce(max_qk_acc, [](auto a, auto b) { return a > b ? a : b; });
-
-    // each wavefront computes partial sum of exp.
-    compute_t softmax_denominator = 0.0f;
-    for(int32_t t = thread_linear_idx; t < t_max; t += threads_per_block)
-    {
-        softmax_denominator += ck::math::exp(smem[t] - max_qk_acc);
-    }
-    softmax_denominator =
-        wavefrontReduce(softmax_denominator, [](auto a, auto b) { return a + b; });
-
-    if(lane_idx == 0)
-    {
-        smem[T_MAX + wavefront_idx] = softmax_denominator;
-    }
-    __syncthreads();
-
-    // now, compute sum of exp(x - max(x)) over all intermediate results.
-    softmax_denominator = 0.0;
-    if(lane_idx < wavefronts_per_block)
-    {
-        softmax_denominator = smem[T_MAX + lane_idx];
-    }
-    softmax_denominator =
-        wavefrontReduce(softmax_denominator, [](auto a, auto b) { return a + b; });
-
-    const compute_t softmax_scale_factor = 1. / softmax_denominator;
-    // now, compute the normalization across all threads.
-    for(int32_t t = thread_linear_idx; t < t_max; t += threads_per_block)
-    {
-        smem[t] = ck::math::exp(smem[t] - max_qk_acc) * softmax_scale_factor;
-    }
-    __syncthreads();
-
-    // Split T across wavefronts in a block
-    // each wavefront compute sum(t_subset) P[t] * V[t_subset, d]
-    // outputs are of size float[D]
-
-    compute_t ps[n_loop_unroll] = {};
-    compute_vec_t o_acc         = 0;
-    if(lane_active_for_io)
-    {
-        for(auto tt = wavefront_idx * n_loop_unroll; tt < t_max_unroll; tt += dtt)
-        {
-#pragma unroll n_loop_unroll
-            for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
-            {
-                const int32_t t = tt + ttt;
-                // load the V[b][t][h|0][:] row into registers, reusing K register
-                // storage
-                load_v<data_t, data_vec_t>(cache_V_base + t * K_stride_1, lane_idx, &k_loads[ttt]);
-                ps[ttt] = smem[t];
-            }
-
-#pragma unroll n_loop_unroll
-            for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
-            {
-                o_acc = scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
-            }
-        }
-
+        // NB: the length of the tail is <= (wavefronts_per_block * n_loop_unroll)
         for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
             tt += wavefronts_per_block * n_loop_unroll_tail)
         {
-#pragma unroll n_loop_unroll_tail
-            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+            if(lane_active_for_io)
             {
-                const int32_t t = tt + ttt;
-                if(t < t_max)
+#pragma unroll n_loop_unroll_tail
+                for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
                 {
-                    // load the V[b][t][h|0][:] row into registers, reusing K register
-                    // storage
-                    load_v<data_t, data_vec_t>(
-                        cache_V_base + t * K_stride_1, lane_idx, &k_loads[ttt]);
-                    ps[ttt] = smem[t];
+                    const int32_t t = tt + ttt;
+                    if(t < t_max)
+                    {
+                        // load the K[b][t][h|0][:] row into registers
+                        load_v<data_t, data_vec_t>(
+                            cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
+                    }
+                    compute_t qk_accs[n_loop_unroll] = {};
+#pragma unroll n_loop_unroll
+                    for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
+                    {
+                        const int32_t t = tt + ttt;
+                        // load the V[b][t][h|0][:] row into registers, reusing K register
+                        // storage
+                        load_v<data_t, data_vec_t>(
+                            cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
+                        ps[ttt] = smem[t];
+                    }
+
+#pragma unroll n_loop_unroll
+                    for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
+                    {
+                        o_acc = scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
+                    }
                 }
-            }
+
+                for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
+                    tt += wavefronts_per_block * n_loop_unroll_tail)
+                {
+#pragma unroll n_loop_unroll_tail
+                    for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+                    {
+                        const int32_t t = tt + ttt;
+                        if(t < t_max)
+                        {
+                            // load the V[b][t][h|0][:] row into registers, reusing K register
+                            // storage
+                            load_v<data_t, data_vec_t>(
+                                cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
+                            ps[ttt] = smem[t];
+                        }
+
+                        for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
+                            tt += wavefronts_per_block * n_loop_unroll_tail)
+                        {
+#pragma unroll n_loop_unroll_tail
+                            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+                            {
+                                const int32_t t = tt + ttt;
+                                if(t < t_max)
+                                {
+                                    // load the V[b][t][h|0][:] row into registers, reusing K
+                                    // register storage
+                                    load_v<data_t, data_vec_t>(
+                                        cache_V_base + t * K_stride_1, lane_idx, &k_loads[ttt]);
+                                    ps[ttt] = smem[t];
+                                }
+                            }
 
 #pragma unroll n_loop_unroll_tail
-            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-            {
-                const int32_t t = tt + ttt;
-                if(t < t_max)
-                {
-                    o_acc = scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
-                }
-            }
-        }
-    }
-    // now, each thread has partial sums. Write to smem and get accumulated
-    // results back.
-    __syncthreads();
+                            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+                            {
+                                const int32_t t = tt + ttt;
+                                if(t < t_max)
+                                {
+                                    o_acc = scalar_scale_acc<data_t, vec_size>(
+                                        o_acc, k_loads[ttt], ps[ttt]);
+                                }
+                            }
+                        }
+                    }
+                    // now, each thread has partial sums. Write to smem and get accumulated
+                    // results back.
+                    __syncthreads();
 
-    // NB: needs sizeof(smem) >= `vec_size` * (sizeof(float)==4) * threadsPerBlock
-    if(lane_active_for_io)
-    {
-        store_v<compute_t, compute_vec_t>(&smem[0], thread_linear_idx, o_acc);
-    }
+                    // NB: needs sizeof(smem) >= `vec_size` * (sizeof(float)==4) * threadsPerBlock
+                    if(lane_active_for_io)
+                    {
+                        store_v<compute_t, compute_vec_t>(&smem[0], thread_linear_idx, o_acc);
+                    }
 
-    __syncthreads();
-    // sum up partial D rows from other wavefronts
-    if(wavefront_idx == 0 && lane_active_for_io)
-    {
-        union
-        {
-            compute_vec_t vec = 0;
-            compute_t arr[vec_size];
-        } r;
-        for(int32_t w = 0; w < wavefronts_per_block; ++w)
-        {
-            compute_vec_t partial_r;
-            load_v<compute_t, compute_vec_t>(
-                smem, w * threads_per_wavefront + lane_idx, &partial_r);
-            r.vec += partial_r;
-        }
-        // elementwise convert from compute_t result to data_t out to be written
-        union
-        {
-            data_vec_t vec;
-            data_t arr[vec_size];
-        } bf_r;
+                    __syncthreads();
+                    // sum up partial D rows from other wavefronts
+                    if(wavefront_idx == 0 && lane_active_for_io)
+                    {
+                        union
+                        {
+                            compute_vec_t vec = 0;
+                            compute_t arr[vec_size];
+                        } r;
+                        for(int32_t w = 0; w < wavefronts_per_block; ++w)
+                        {
+                            compute_vec_t partial_r;
+                            load_v<compute_t, compute_vec_t>(
+                                smem, w * threads_per_wavefront + lane_idx, &partial_r);
+                            r.vec += partial_r;
+                        }
+                        // elementwise convert from compute_t result to data_t out to be written
+                        union
+                        {
+                            data_vec_t vec;
+                            data_t arr[vec_size];
+                        } bf_r;
 #pragma unroll
-        for(int32_t i = 0; i < vec_size; ++i)
-        {
-            bf_r.arr[i] = ck::type_convert<data_t>(r.arr[i]);
-        }
-        // write output row O[b][m][h][:]
-        data_t* __restrict__ o_ = O + XQO_base_offset;
-        store_v<data_t, data_vec_t>(o_, lane_idx, bf_r.vec);
-    }
-}
-
-} // namespace
-
-namespace ck {
-namespace tensor_operation {
-namespace device {
-template <typename scalar_t>
-struct FMHADecoderSeqlen1DeviceOp : public BaseOperator
-{
-    using DeviceOp = FMHADecoderSeqlen1DeviceOp;
-    struct Argument : public BaseArgument
-    {
-        const scalar_t* __restrict__ XQ;
-        const scalar_t* __restrict__ cache_K;
-        const scalar_t* __restrict__ cache_V;
-        scalar_t* __restrict__ O;
-        const int32_t* __restrict__ seq_kv_lens;
-        const ptrdiff_t XQ_stride_0;
-        const ptrdiff_t XQ_stride_1;
-        const ptrdiff_t XQ_stride_2;
-        const ptrdiff_t K_stride_0;
-        const ptrdiff_t K_stride_1;
-        const ptrdiff_t K_stride_2;
-        const int32_t K_size_1;
-        const int32_t D_H;
-        const bool multiquery;
-        const float qk_scale;
-
-        const dim3 grid_dim;
-        const dim3 block_dim;
-        const size_t lds_bytes;
-
-        Argument(const scalar_t* __restrict__ XQ,
-                 const scalar_t* __restrict__ cache_K,
-                 const scalar_t* __restrict__ cache_V,
-                 scalar_t* __restrict__ O,
-                 const int32_t* __restrict__ seq_kv_lens,
-                 const ptrdiff_t XQ_stride_0,
-                 const ptrdiff_t XQ_stride_1,
-                 const ptrdiff_t XQ_stride_2,
-                 const ptrdiff_t K_stride_0,
-                 const ptrdiff_t K_stride_1,
-                 const ptrdiff_t K_stride_2,
-                 const int32_t K_size_1,
-                 const int32_t D_H,
-                 const bool multiquery,
-                 const float qk_scale,
-                 const dim3 grid_dim,
-                 const dim3 block_dim,
-                 const size_t lds_bytes)
-            : XQ(XQ),
-              cache_K(cache_K),
-              cache_V(cache_V),
-              O(O),
-              seq_kv_lens(seq_kv_lens),
-              XQ_stride_0(XQ_stride_0),
-              XQ_stride_1(XQ_stride_1),
-              XQ_stride_2(XQ_stride_2),
-              K_stride_0(K_stride_0),
-              K_stride_1(K_stride_1),
-              K_stride_2(K_stride_2),
-              K_size_1(K_size_1),
-              D_H(D_H),
-              multiquery(multiquery),
-              qk_scale(qk_scale),
-              grid_dim(grid_dim),
-              block_dim(block_dim),
-              lds_bytes(lds_bytes)
-        {
-        }
-    };
-
-    struct Invoker : public BaseInvoker
-    {
-        using Argument = DeviceOp::Argument;
-        float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
-        {
-            auto threads_per_wavefront = arg.block_dim.x;
-
-            auto D_H_alignment_necessary = 0;
-
-            for(auto vec_size : {4, 2, 1})
-            {
-                if(arg.D_H <= vec_size * threads_per_wavefront)
-                {
-                    D_H_alignment_necessary = vec_size;
+                        for(int32_t i = 0; i < vec_size; ++i)
+                        {
+                            bf_r.arr[i] = ck::type_convert<data_t>(r.arr[i]);
+                        }
+                        // write output row O[b][m][h][:]
+                        data_t* __restrict__ o_ = O + XQO_base_offset;
+                        store_v<data_t, data_vec_t>(o_, lane_idx, bf_r.vec);
+                    }
                 }
-            }
 
-            if(!D_H_alignment_necessary)
+            } // namespace
+
+            namespace ck {
+            namespace tensor_operation {
+            namespace device {
+            template <typename scalar_t>
+            struct FMHADecoderSeqlen1DeviceOp : public BaseOperator
             {
-                throw std::runtime_error("Unsupported D_H");
-            }
+                using DeviceOp = FMHADecoderSeqlen1DeviceOp;
+                struct Argument : public BaseArgument
+                {
+                    const scalar_t* __restrict__ XQ;
+                    const scalar_t* __restrict__ cache_K;
+                    const scalar_t* __restrict__ cache_V;
+                    scalar_t* __restrict__ O;
+                    const int32_t* __restrict__ seq_kv_lens;
+                    const ptrdiff_t XQ_stride_b;
+                    const ptrdiff_t XQ_stride_m;
+                    const ptrdiff_t XQ_stride_h;
+                    const ptrdiff_t K_stride_b;
+                    const ptrdiff_t K_stride_m;
+                    const ptrdiff_t K_stride_h;
+                    const int32_t Q_size_m;
+                    const int32_t Q_size_h;
+                    const int32_t Q_size_k;
+                    const int32_t K_size_m;
+                    const bool multiquery;
+                    const float qk_scale;
 
-            if(arg.D_H % D_H_alignment_necessary)
-            {
-                throw std::runtime_error("Unsupported alignment for D_H");
-            }
+                    const dim3 grid_dim;
+                    const dim3 block_dim;
+                    const size_t lds_bytes;
 
-            return launch_and_time_kernel(
-                stream_config,
-                D_H_alignment_necessary == 4
-                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 4>
-                    : D_H_alignment_necessary == 2
-                          ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 2>
-                          : D_H_alignment_necessary == 1
+                    Argument(const scalar_t* __restrict__ XQ,
+                             const scalar_t* __restrict__ cache_K,
+                             const scalar_t* __restrict__ cache_V,
+                             scalar_t* __restrict__ O,
+                             const int32_t* __restrict__ seq_kv_lens,
+                             const ptrdiff_t XQ_stride_b,
+                             const ptrdiff_t XQ_stride_m,
+                             const ptrdiff_t XQ_stride_h,
+                             const ptrdiff_t K_stride_b,
+                             const ptrdiff_t K_stride_m,
+                             const ptrdiff_t K_stride_h,
+                             const int32_t Q_size_m,
+                             const int32_t Q_size_h,
+                             const int32_t Q_size_k,
+                             const int32_t K_size_m,
+                             const bool multiquery,
+                             const float qk_scale,
+                             const dim3 grid_dim,
+                             const dim3 block_dim,
+                             const size_t lds_bytes)
+                        : XQ(XQ),
+                          cache_K(cache_K),
+                          cache_V(cache_V),
+                          O(O),
+                          seq_kv_lens(seq_kv_lens),
+                          XQ_stride_b(XQ_stride_b),
+                          XQ_stride_m(XQ_stride_m),
+                          XQ_stride_h(XQ_stride_h),
+                          K_stride_b(K_stride_b),
+                          K_stride_m(K_stride_m),
+                          K_stride_h(K_stride_h),
+                          Q_size_m(Q_size_m),
+                          Q_size_h(Q_size_h),
+                          Q_size_k(Q_size_k),
+                          K_size_m(K_size_m),
+                          multiquery(multiquery),
+                          qk_scale(qk_scale),
+                          grid_dim(grid_dim),
+                          block_dim(block_dim),
+                          lds_bytes(lds_bytes)
+                    {
+                    }
+                };
+
+                struct Invoker : public BaseInvoker
+                {
+                    using Argument = DeviceOp::Argument;
+                    float Run(const Argument& arg,
+                              const StreamConfig& stream_config = StreamConfig{})
+                    {
+                        auto threads_per_wavefront = arg.block_dim.x;
+
+                        auto Q_size_k_alignment_necessary = 0;
+
+                        for(auto vec_size : {4, 2, 1})
+                        {
+                            if(arg.Q_size_k <= vec_size * threads_per_wavefront)
+                            {
+                                Q_size_k_alignment_necessary = vec_size;
+                            }
+                        };
+
+                        if(!Q_size_k_alignment_necessary)
+                        {
+                            throw std::runtime_error("Unsupported Q_size_k");
+                        }
+
+                        if(arg.Q_size_k % Q_size_k_alignment_necessary)
+                        {
+                            throw std::runtime_error("Unsupported alignment for Q_size_k");
+                        }
+
+                        return launch_and_time_kernel(
+                            stream_config,
+                            Q_size_k_alignment_necessary == 4
+                                ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 4>
+                            : Q_size_k_alignment_necessary == 2
+                                ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 2>
+                            : Q_size_k_alignment_necessary == 1
                                 ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 1>
                                 : nullptr,
-                arg.grid_dim,
-                arg.block_dim,
-                arg.lds_bytes,
-                arg.XQ,
-                arg.cache_K,
-                arg.cache_V,
-                arg.O,
-                arg.seq_kv_lens,
-                arg.XQ_stride_0,
-                arg.XQ_stride_1,
-                arg.XQ_stride_2,
-                arg.K_stride_0,
-                arg.K_stride_1,
-                arg.K_stride_2,
-                arg.K_size_1,
-                arg.D_H,
-                arg.multiquery,
-                arg.qk_scale);
-        }
-    };
-};
-} // namespace device
-} // namespace tensor_operation
-} // namespace ck
+                            arg.grid_dim,
+                            arg.block_dim,
+                            arg.lds_bytes,
+                            arg.XQ,
+                            arg.cache_K,
+                            arg.cache_V,
+                            arg.O,
+                            arg.seq_kv_lens,
+                            arg.XQ_stride_b,
+                            arg.XQ_stride_m,
+                            arg.XQ_stride_h,
+                            arg.K_stride_b,
+                            arg.K_stride_m,
+                            arg.K_stride_h,
+                            arg.Q_size_m,
+                            arg.Q_size_h,
+                            arg.Q_size_k,
+                            arg.K_size_m,
+                            arg.multiquery,
+                            arg.qk_scale);
+                    }
+                };
+            };
+            } // namespace device
+            } // namespace tensor_operation
+            } // namespace ck

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
@@ -106,7 +106,7 @@ template <typename scalar_t,
           int32_t vec_size               = 4,
           int32_t n_loop_unroll          = 16,
           int32_t n_loop_unroll_tail     = 2,
-          int32_t T_MAX                  = 8192,
+          int32_t KV_M_MAX               = 8192,
           int32_t n_wavefronts_per_block = 16>
 __global__ void
 efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
@@ -158,9 +158,6 @@ efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
     const auto* __restrict__ cache_K_base = cache_K + cache_KV_base_offset;
     const auto* __restrict__ cache_V_base = cache_V + cache_KV_base_offset;
 
-    // Load Q into registers in all wavefronts.
-    // Each thread handles `vec_size` D dimensions
-
     using data_t        = scalar_t;
     using data_vec_t    = typename ck::vector_type<data_t, vec_size>::type;
     using compute_t     = float;
@@ -171,16 +168,24 @@ efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
     extern __shared__ __align__(16) compute_t smem[];
 
     data_vec_t q_thread = 0;
+    // Load Q into registers in all wavefronts.
+    // Each thread handles `vec_size` D dimensions
     if(lane_active_for_io)
     {
         load_v<data_t, data_vec_t>(q_, lane_idx, &q_thread);
     }
-    // Each block computes different B value
+
     compute_t max_qk_acc = ck::NumericLimits<compute_t>::Lowest();
 
-    // Compute S[T_MAX] = for i in range(T): S[t] = sum(Q[d] * K[t, d])
-    // Split T across wavefronts in a block, unroll loads to expose more
-    // parallelism.
+    // Compute S[0:t_max] =
+    // ```
+    // for t in range(t_max):
+    //   S[t] = dot(Q, K[t])
+    // ```
+    // Split the 0:t_max range across wavefronts in a block,
+    // unroll loads to expose more parallelism.
+    // Reduce the dot product with cross-lane operation;
+    // Q and K[t] are in the registers of threads in a single wavefront.
 
     data_vec_t k_loads[n_loop_unroll] = {};
 
@@ -206,288 +211,358 @@ efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
         // Split T across wavefronts in a block, unroll loads to expose more
         // parallelism.
 
-        // NB: the length of the tail is <= (wavefronts_per_block * n_loop_unroll)
-        for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
-            tt += wavefronts_per_block * n_loop_unroll_tail)
+        data_vec_t k_loads[n_loop_unroll] = {};
+
+        constexpr auto dtt         = n_wavefronts_per_block * n_loop_unroll;
+        const int32_t t_max_unroll = (t_max / dtt) * dtt;
+
+        for(auto tt = wavefront_idx * n_loop_unroll; tt < t_max_unroll; tt += dtt)
         {
             if(lane_active_for_io)
             {
-#pragma unroll n_loop_unroll_tail
-                for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+#pragma unroll n_loop_unroll
+                for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
                 {
                     const int32_t t = tt + ttt;
-                    if(t < t_max)
-                    {
-                        // load the K[b][t][g][h|0][:] row into registers
-                        load_v<data_t, data_vec_t>(
-                            cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
-                    }
-                    // Each block computes different B value
-                    compute_t max_qk_acc = ck::NumericLimits<compute_t>::Lowest();
+                    // load the K[b][t][g][h|0][:] row into registers
+                    load_v<data_t, data_vec_t>(
+                        cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
+                }
+            }
+            // Each block computes different B value
+            compute_t max_qk_acc = ck::NumericLimits<compute_t>::Lowest();
 
-                    // Compute S[T_MAX] = for i in range(T): S[t] = sum(Q[d] * K[t, d])
-                    // Split T across wavefronts in a block, unroll loads to expose more
-                    // parallelism.
+            // Compute S[T_MAX] = for i in range(T): S[t] = sum(Q[d] * K[t, d])
+            // Split T across wavefronts in a block, unroll loads to expose more
+            // parallelism.
 
-                    // NB: the length of the tail is <= (wavefronts_per_block * n_loop_unroll)
-                    for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
-                        tt += wavefronts_per_block * n_loop_unroll_tail)
-                    {
-                        if(lane_active_for_io)
-                        {
-#pragma unroll n_loop_unroll_tail
-                            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-                            {
-                                const int32_t t = tt + ttt;
-                                if(t < t_max)
-                                {
-                                    // load the K[b][t][h|0][:] row into registers
-                                    load_v<data_t, data_vec_t>(
-                                        cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
-                                }
-                                compute_t qk_accs[n_loop_unroll] = {};
-#pragma unroll n_loop_unroll
-                                for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
-                                {
-                                    const int32_t t = tt + ttt;
-                                    // load the V[b][t][g][h|0][:] row into registers, reusing K
-                                    // register storage
-                                    load_v<data_t, data_vec_t>(
-                                        cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
-                                    ps[ttt] = smem[t];
-                                }
-
-#pragma unroll n_loop_unroll
-                                for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
-                                {
-                                    o_acc = scalar_scale_acc<data_t, vec_size>(
-                                        o_acc, k_loads[ttt], ps[ttt]);
-                                }
-                            }
-
-                            for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail;
-                                tt < t_max;
-                                tt += wavefronts_per_block * n_loop_unroll_tail)
-                            {
-#pragma unroll n_loop_unroll_tail
-                                for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-                                {
-                                    const int32_t t = tt + ttt;
-                                    if(t < t_max)
-                                    {
-                                        // load the V[b][t][g][h|0][:] row into registers, reusing K
-                                        // register storage
-                                        load_v<data_t, data_vec_t>(
-                                            cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
-                                        ps[ttt] = smem[t];
-                                    }
-                                }
-
-#pragma unroll n_loop_unroll_tail
-                                for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-                                {
-                                    const int32_t t = tt + ttt;
-                                    if(t < t_max)
-                                    {
-                                        o_acc = scalar_scale_acc<data_t, vec_size>(
-                                            o_acc, k_loads[ttt], ps[ttt]);
-                                    }
-                                }
-                            }
-                        }
-                        // now, each thread has partial sums. Write to smem and get accumulated
-                        // results back.
-                        __syncthreads();
-
-                        // NB: needs sizeof(smem) >= `vec_size` * (sizeof(float)==4) *
-                        // threadsPerBlock
-                        if(lane_active_for_io)
-                        {
-                            store_v<compute_t, compute_vec_t>(&smem[0], thread_linear_idx, o_acc);
-                        }
-
-                        __syncthreads();
-                        // sum up partial D rows from other wavefronts
-                        if(wavefront_idx == 0 && lane_active_for_io)
-                        {
-                            union
-                            {
-                                compute_vec_t vec = 0;
-                                compute_t arr[vec_size];
-                            } r;
-                            for(int32_t w = 0; w < wavefronts_per_block; ++w)
-                            {
-                                compute_vec_t partial_r;
-                                load_v<compute_t, compute_vec_t>(
-                                    smem, w * threads_per_wavefront + lane_idx, &partial_r);
-                                r.vec += partial_r;
-                            }
-                            // elementwise convert from compute_t result to data_t out to be written
-                            union
-                            {
-                                data_vec_t vec;
-                                data_t arr[vec_size];
-                            } bf_r;
-#pragma unroll
-                            for(int32_t i = 0; i < vec_size; ++i)
-                            {
-                                bf_r.arr[i] = ck::type_convert<data_t>(r.arr[i]);
-                            }
-                            // write output row O[b][m][g][h][:]
-                            data_t* __restrict__ o_ = O + XQO_base_offset;
-                            store_v<data_t, data_vec_t>(o_, lane_idx, bf_r.vec);
-                        }
-                    }
-
-                } // namespace
-
-                namespace ck {
-                namespace tensor_operation {
-                namespace device {
-                template <typename scalar_t>
-                struct FMHADecoderSeqlen1DeviceOp : public BaseOperator
+            // NB: the length of the tail is <= (wavefronts_per_block * n_loop_unroll)
+            for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
+                tt += wavefronts_per_block * n_loop_unroll_tail)
+            {
+                if(lane_active_for_io)
                 {
-                    using DeviceOp = FMHADecoderSeqlen1DeviceOp;
-                    struct Argument : public BaseArgument
+#pragma unroll n_loop_unroll_tail
+                    for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
                     {
-                        const scalar_t* __restrict__ XQ;
-                        const scalar_t* __restrict__ cache_K;
-                        const scalar_t* __restrict__ cache_V;
-                        scalar_t* __restrict__ O;
-                        const int32_t* __restrict__ seq_kv_lens;
-                        const ptrdiff_t XQ_stride_b;
-                        const ptrdiff_t XQ_stride_m;
-                        const ptrdiff_t XQ_stride_g;
-                        const ptrdiff_t XQ_stride_h;
-                        const ptrdiff_t K_stride_b;
-                        const ptrdiff_t K_stride_m;
-                        const ptrdiff_t K_stride_g;
-                        const ptrdiff_t K_stride_h;
-                        const int32_t Q_size_m;
-                        const int32_t Q_size_g;
-                        const int32_t Q_size_h;
-                        const int32_t Q_size_k;
-                        const int32_t K_size_m;
-                        const bool multiquery;
-                        const float qk_scale;
-
-                        const dim3 grid_dim;
-                        const dim3 block_dim;
-                        const size_t lds_bytes;
-
-                        Argument(const scalar_t* __restrict__ XQ,
-                                 const scalar_t* __restrict__ cache_K,
-                                 const scalar_t* __restrict__ cache_V,
-                                 scalar_t* __restrict__ O,
-                                 const int32_t* __restrict__ seq_kv_lens,
-                                 const ptrdiff_t XQ_stride_b,
-                                 const ptrdiff_t XQ_stride_m,
-                                 const ptrdiff_t XQ_stride_g,
-                                 const ptrdiff_t XQ_stride_h,
-                                 const ptrdiff_t K_stride_b,
-                                 const ptrdiff_t K_stride_m,
-                                 const ptrdiff_t K_stride_g,
-                                 const ptrdiff_t K_stride_h,
-                                 const int32_t Q_size_m,
-                                 const int32_t Q_size_g,
-                                 const int32_t Q_size_h,
-                                 const int32_t Q_size_k,
-                                 const int32_t K_size_m,
-                                 const bool multiquery,
-                                 const float qk_scale,
-                                 const dim3 grid_dim,
-                                 const dim3 block_dim,
-                                 const size_t lds_bytes)
-                            : XQ(XQ),
-                              cache_K(cache_K),
-                              cache_V(cache_V),
-                              O(O),
-                              seq_kv_lens(seq_kv_lens),
-                              XQ_stride_b(XQ_stride_b),
-                              XQ_stride_m(XQ_stride_m),
-                              XQ_stride_g(XQ_stride_g),
-                              XQ_stride_h(XQ_stride_h),
-                              K_stride_b(K_stride_b),
-                              K_stride_m(K_stride_m),
-                              K_stride_g(K_stride_g),
-                              K_stride_h(K_stride_h),
-                              Q_size_m(Q_size_m),
-                              Q_size_g(Q_size_g),
-                              Q_size_h(Q_size_h),
-                              Q_size_k(Q_size_k),
-                              K_size_m(K_size_m),
-                              multiquery(multiquery),
-                              qk_scale(qk_scale),
-                              grid_dim(grid_dim),
-                              block_dim(block_dim),
-                              lds_bytes(lds_bytes)
+                        const int32_t t = tt + ttt;
+                        if(t < t_max)
                         {
+                            // load the K[b][t][g][h|0][:] row into registers
+                            load_v<data_t, data_vec_t>(
+                                cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
                         }
-                    };
+                        // Each block computes different B value
+                        compute_t max_qk_acc = ck::NumericLimits<compute_t>::Lowest();
 
-                    struct Invoker : public BaseInvoker
+                        // Compute S[T_MAX] = for i in range(T): S[t] = sum(Q[d] * K[t, d])
+                        // Split T across wavefronts in a block, unroll loads to expose more
+                        // parallelism.
+
+                        // write accumulated sums to smem.
+                        if(lane_idx == 0)
+                        {
+                            smem[t] = qk_acc;
+                        }
+                    }
+                }
+            }
+
+            // Use shared reduction to compute max and compute softmax on shared memory.
+            // write max acc
+            if(lane_idx == 0)
+            {
+                smem[KV_M_MAX + wavefront_idx] = max_qk_acc;
+            }
+            __syncthreads();
+            if(lane_idx < wavefronts_per_block)
+            {
+                max_qk_acc = ck::math::max(max_qk_acc, smem[KV_M_MAX + lane_idx]);
+            }
+            // shared across all threads in block
+            max_qk_acc = wavefrontReduce(max_qk_acc, [](auto a, auto b) { return a > b ? a : b; });
+
+            // each wavefront computes partial sum of exp.
+            compute_t softmax_denominator = 0.0f;
+            for(int32_t t = thread_linear_idx; t < t_max; t += threads_per_block)
+            {
+                softmax_denominator += ck::math::exp(smem[t] - max_qk_acc);
+            }
+            softmax_denominator =
+                wavefrontReduce(softmax_denominator, [](auto a, auto b) { return a + b; });
+
+            if(lane_idx == 0)
+            {
+                smem[KV_M_MAX + wavefront_idx] = softmax_denominator;
+            }
+            __syncthreads();
+
+            // now, compute sum of exp(x - max(x)) over all intermediate results.
+            softmax_denominator = 0.0;
+            if(lane_idx < wavefronts_per_block)
+            {
+                softmax_denominator = smem[KV_M_MAX + lane_idx];
+            }
+            softmax_denominator =
+                wavefrontReduce(softmax_denominator, [](auto a, auto b) { return a + b; });
+
+            const compute_t softmax_scale_factor = 1. / softmax_denominator;
+            // now, compute the normalization across all threads.
+            for(int32_t t = thread_linear_idx; t < t_max; t += threads_per_block)
+            {
+                smem[t] = ck::math::exp(smem[t] - max_qk_acc) * softmax_scale_factor;
+            }
+            __syncthreads();
+
+            // Split T across wavefronts in a block
+            // each wavefront compute sum(t_subset) P[t] * V[t_subset, d]
+            // outputs are of size float[D]
+
+            compute_t ps[n_loop_unroll] = {};
+            compute_vec_t o_acc         = 0;
+            if(lane_active_for_io)
+            {
+                for(auto tt = wavefront_idx * n_loop_unroll; tt < t_max_unroll; tt += dtt)
+                {
+#pragma unroll n_loop_unroll
+                    for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
                     {
-                        using Argument = DeviceOp::Argument;
-                        float Run(const Argument& arg,
-                                  const StreamConfig& stream_config = StreamConfig{})
+                        const int32_t t = tt + ttt;
+                        // load the V[b][t][g][h|0][:] row into registers, reusing K
+                        // register storage
+                        load_v<data_t, data_vec_t>(
+                            cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
+                        ps[ttt] = smem[t];
+                    }
+
+#pragma unroll n_loop_unroll
+                    for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
+                    {
+                        o_acc = scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
+                    }
+                }
+
+                for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
+                    tt += wavefronts_per_block * n_loop_unroll_tail)
+                {
+#pragma unroll n_loop_unroll_tail
+                    for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+                    {
+                        const int32_t t = tt + ttt;
+                        if(t < t_max)
                         {
-                            auto threads_per_wavefront = arg.block_dim.x;
-
-                            auto Q_size_k_alignment_necessary = 0;
-
-                            for(auto vec_size : {4, 2, 1})
-                            {
-                                if(arg.Q_size_k <= vec_size * threads_per_wavefront)
-                                {
-                                    Q_size_k_alignment_necessary = vec_size;
-                                }
-                            };
-
-                            if(!Q_size_k_alignment_necessary)
-                            {
-                                throw std::runtime_error("Unsupported Q_size_k");
-                            }
-
-                            if(arg.Q_size_k % Q_size_k_alignment_necessary)
-                            {
-                                throw std::runtime_error("Unsupported alignment for Q_size_k");
-                            }
-
-                            return launch_and_time_kernel(
-                                stream_config,
-                                Q_size_k_alignment_necessary == 4
-                                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 4>
-                                : Q_size_k_alignment_necessary == 2
-                                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 2>
-                                : Q_size_k_alignment_necessary == 1
-                                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 1>
-                                    : nullptr,
-                                arg.grid_dim,
-                                arg.block_dim,
-                                arg.lds_bytes,
-                                arg.XQ,
-                                arg.cache_K,
-                                arg.cache_V,
-                                arg.O,
-                                arg.seq_kv_lens,
-                                arg.XQ_stride_b,
-                                arg.XQ_stride_m,
-                                arg.XQ_stride_g,
-                                arg.XQ_stride_h,
-                                arg.K_stride_b,
-                                arg.K_stride_m,
-                                arg.K_stride_g,
-                                arg.K_stride_h,
-                                arg.Q_size_m,
-                                arg.Q_size_g,
-                                arg.Q_size_h,
-                                arg.Q_size_k,
-                                arg.K_size_m,
-                                arg.multiquery,
-                                arg.qk_scale);
+                            // load the V[b][t][g][h|0][:] row into registers, reusing K
+                            // register storage
+                            load_v<data_t, data_vec_t>(
+                                cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
+                            ps[ttt] = smem[t];
                         }
-                    };
+                    }
+
+#pragma unroll n_loop_unroll_tail
+                    for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+                    {
+                        const int32_t t = tt + ttt;
+                        if(t < t_max)
+                        {
+                            o_acc =
+                                scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
+                        }
+                    }
+                }
+            }
+            // now, each thread has partial sums. Write to smem and get accumulated
+            // results back.
+            __syncthreads();
+
+            // NB: needs sizeof(smem) >= `vec_size` * (sizeof(float)==4) *
+            // threadsPerBlock
+            if(lane_active_for_io)
+            {
+                store_v<compute_t, compute_vec_t>(&smem[0], thread_linear_idx, o_acc);
+            }
+
+            __syncthreads();
+            // sum up partial D rows from other wavefronts
+            if(wavefront_idx == 0 && lane_active_for_io)
+            {
+                union
+                {
+                    compute_vec_t vec = 0;
+                    compute_t arr[vec_size];
+                } r;
+                for(int32_t w = 0; w < wavefronts_per_block; ++w)
+                {
+                    compute_vec_t partial_r;
+                    load_v<compute_t, compute_vec_t>(
+                        smem, w * threads_per_wavefront + lane_idx, &partial_r);
+                    r.vec += partial_r;
+                }
+                // elementwise convert from compute_t result to data_t out to be written
+                union
+                {
+                    data_vec_t vec;
+                    data_t arr[vec_size];
+                } bf_r;
+#pragma unroll
+                for(int32_t i = 0; i < vec_size; ++i)
+                {
+                    bf_r.arr[i] = ck::type_convert<data_t>(r.arr[i]);
+                }
+                // write output row O[b][m][g][h][:]
+                data_t* __restrict__ o_ = O + XQO_base_offset;
+                store_v<data_t, data_vec_t>(o_, lane_idx, bf_r.vec);
+            }
+        }
+
+    } // namespace
+
+    namespace ck {
+    namespace tensor_operation {
+    namespace device {
+    template <typename scalar_t>
+    struct FMHADecoderSeqlen1DeviceOp : public BaseOperator
+    {
+        using DeviceOp = FMHADecoderSeqlen1DeviceOp;
+        struct Argument : public BaseArgument
+        {
+            const scalar_t* __restrict__ XQ;
+            const scalar_t* __restrict__ cache_K;
+            const scalar_t* __restrict__ cache_V;
+            scalar_t* __restrict__ O;
+            const int32_t* __restrict__ seq_kv_lens;
+            const ptrdiff_t XQ_stride_b;
+            const ptrdiff_t XQ_stride_m;
+            const ptrdiff_t XQ_stride_g;
+            const ptrdiff_t XQ_stride_h;
+            const ptrdiff_t K_stride_b;
+            const ptrdiff_t K_stride_m;
+            const ptrdiff_t K_stride_g;
+            const ptrdiff_t K_stride_h;
+            const int32_t Q_size_m;
+            const int32_t Q_size_g;
+            const int32_t Q_size_h;
+            const int32_t Q_size_k;
+            const int32_t K_size_m;
+            const bool multiquery;
+            const float qk_scale;
+
+            const dim3 grid_dim;
+            const dim3 block_dim;
+            const size_t lds_bytes;
+
+            Argument(const scalar_t* __restrict__ XQ,
+                     const scalar_t* __restrict__ cache_K,
+                     const scalar_t* __restrict__ cache_V,
+                     scalar_t* __restrict__ O,
+                     const int32_t* __restrict__ seq_kv_lens,
+                     const ptrdiff_t XQ_stride_b,
+                     const ptrdiff_t XQ_stride_m,
+                     const ptrdiff_t XQ_stride_g,
+                     const ptrdiff_t XQ_stride_h,
+                     const ptrdiff_t K_stride_b,
+                     const ptrdiff_t K_stride_m,
+                     const ptrdiff_t K_stride_g,
+                     const ptrdiff_t K_stride_h,
+                     const int32_t Q_size_m,
+                     const int32_t Q_size_g,
+                     const int32_t Q_size_h,
+                     const int32_t Q_size_k,
+                     const int32_t K_size_m,
+                     const bool multiquery,
+                     const float qk_scale,
+                     const dim3 grid_dim,
+                     const dim3 block_dim,
+                     const size_t lds_bytes)
+                : XQ(XQ),
+                  cache_K(cache_K),
+                  cache_V(cache_V),
+                  O(O),
+                  seq_kv_lens(seq_kv_lens),
+                  XQ_stride_b(XQ_stride_b),
+                  XQ_stride_m(XQ_stride_m),
+                  XQ_stride_g(XQ_stride_g),
+                  XQ_stride_h(XQ_stride_h),
+                  K_stride_b(K_stride_b),
+                  K_stride_m(K_stride_m),
+                  K_stride_g(K_stride_g),
+                  K_stride_h(K_stride_h),
+                  Q_size_m(Q_size_m),
+                  Q_size_g(Q_size_g),
+                  Q_size_h(Q_size_h),
+                  Q_size_k(Q_size_k),
+                  K_size_m(K_size_m),
+                  multiquery(multiquery),
+                  qk_scale(qk_scale),
+                  grid_dim(grid_dim),
+                  block_dim(block_dim),
+                  lds_bytes(lds_bytes)
+            {
+            }
+        };
+
+        struct Invoker : public BaseInvoker
+        {
+            using Argument = DeviceOp::Argument;
+            float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
+            {
+                auto threads_per_wavefront = arg.block_dim.x;
+
+                auto Q_size_k_alignment_necessary = 0;
+
+                for(auto vec_size : {4, 2, 1})
+                {
+                    if(arg.Q_size_k <= vec_size * threads_per_wavefront)
+                    {
+                        Q_size_k_alignment_necessary = vec_size;
+                    }
                 };
-                } // namespace device
-                } // namespace tensor_operation
-                } // namespace ck
+
+                if(!Q_size_k_alignment_necessary)
+                {
+                    throw std::runtime_error("Unsupported Q_size_k");
+                }
+
+                if(arg.Q_size_k % Q_size_k_alignment_necessary)
+                {
+                    throw std::runtime_error("Unsupported alignment for Q_size_k");
+                }
+
+                return launch_and_time_kernel(
+                    stream_config,
+                    Q_size_k_alignment_necessary == 4
+                        ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 4>
+                    : Q_size_k_alignment_necessary == 2
+                        ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 2>
+                    : Q_size_k_alignment_necessary == 1
+                        ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 1>
+                        : nullptr,
+                    arg.grid_dim,
+                    arg.block_dim,
+                    arg.lds_bytes,
+                    arg.XQ,
+                    arg.cache_K,
+                    arg.cache_V,
+                    arg.O,
+                    arg.seq_kv_lens,
+                    arg.XQ_stride_b,
+                    arg.XQ_stride_m,
+                    arg.XQ_stride_g,
+                    arg.XQ_stride_h,
+                    arg.K_stride_b,
+                    arg.K_stride_m,
+                    arg.K_stride_g,
+                    arg.K_stride_h,
+                    arg.Q_size_m,
+                    arg.Q_size_g,
+                    arg.Q_size_h,
+                    arg.Q_size_k,
+                    arg.K_size_m,
+                    arg.multiquery,
+                    arg.qk_scale);
+            }
+        };
+    };
+    } // namespace device
+    } // namespace tensor_operation
+    } // namespace ck

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder.h
@@ -204,365 +204,361 @@ efficient_attention_forward_decoder_ck_kernel(const scalar_t* __restrict__ XQ,
                 load_v<data_t, data_vec_t>(cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
             }
         }
-        // Each block computes different B value
-        compute_t max_qk_acc = ck::NumericLimits<compute_t>::Lowest();
-
-        // Compute S[T_MAX] = for i in range(T): S[t] = sum(Q[d] * K[t, d])
-        // Split T across wavefronts in a block, unroll loads to expose more
-        // parallelism.
-
-        data_vec_t k_loads[n_loop_unroll] = {};
-
-        constexpr auto dtt         = n_wavefronts_per_block * n_loop_unroll;
-        const int32_t t_max_unroll = (t_max / dtt) * dtt;
-
-        for(auto tt = wavefront_idx * n_loop_unroll; tt < t_max_unroll; tt += dtt)
-        {
-            if(lane_active_for_io)
-            {
+        compute_t qk_accs[n_loop_unroll] = {};
 #pragma unroll n_loop_unroll
-                for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
+        for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
+        {
+            ck::inner_product<data_vec_t, data_vec_t, compute_t>(
+                q_thread, k_loads[ttt], qk_accs[ttt]);
+            qk_accs[ttt] *= qk_scale;
+
+            qk_accs[ttt] = wavefrontReduce(qk_accs[ttt], [](auto a, auto b) { return a + b; });
+            max_qk_acc   = ck::math::max(qk_accs[ttt], max_qk_acc);
+        }
+        if(lane_idx == 0)
+        {
+            auto* __restrict__ smem_base = smem + tt;
+#pragma unroll n_loop_unroll
+            for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
+            {
+                smem_base[ttt] = qk_accs[ttt];
+            }
+        }
+    }
+
+    // NB: the length of the tail is <= (wavefronts_per_block * n_loop_unroll)
+    for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
+        tt += wavefronts_per_block * n_loop_unroll_tail)
+    {
+        if(lane_active_for_io)
+        {
+#pragma unroll n_loop_unroll_tail
+            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+            {
+                const int32_t t = tt + ttt;
+                if(t < t_max)
                 {
-                    const int32_t t = tt + ttt;
                     // load the K[b][t][g][h|0][:] row into registers
                     load_v<data_t, data_vec_t>(
                         cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
                 }
             }
-            // Each block computes different B value
-            compute_t max_qk_acc = ck::NumericLimits<compute_t>::Lowest();
-
-            // Compute S[T_MAX] = for i in range(T): S[t] = sum(Q[d] * K[t, d])
-            // Split T across wavefronts in a block, unroll loads to expose more
-            // parallelism.
-
-            // NB: the length of the tail is <= (wavefronts_per_block * n_loop_unroll)
-            for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
-                tt += wavefronts_per_block * n_loop_unroll_tail)
-            {
-                if(lane_active_for_io)
-                {
+        }
 #pragma unroll n_loop_unroll_tail
-                    for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-                    {
-                        const int32_t t = tt + ttt;
-                        if(t < t_max)
-                        {
-                            // load the K[b][t][g][h|0][:] row into registers
-                            load_v<data_t, data_vec_t>(
-                                cache_K_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
-                        }
-                        // Each block computes different B value
-                        compute_t max_qk_acc = ck::NumericLimits<compute_t>::Lowest();
+        for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+        {
+            compute_t qk_acc = 0;
+            const int32_t t  = tt + ttt;
+            if(t < t_max)
+            {
+                ck::inner_product<data_vec_t, data_vec_t, compute_t>(
+                    q_thread, k_loads[ttt], qk_acc);
+                qk_acc *= qk_scale;
 
-                        // Compute S[T_MAX] = for i in range(T): S[t] = sum(Q[d] * K[t, d])
-                        // Split T across wavefronts in a block, unroll loads to expose more
-                        // parallelism.
+                qk_acc     = wavefrontReduce(qk_acc, [](auto a, auto b) { return a + b; });
+                max_qk_acc = ck::math::max(qk_acc, max_qk_acc);
 
-                        // write accumulated sums to smem.
-                        if(lane_idx == 0)
-                        {
-                            smem[t] = qk_acc;
-                        }
-                    }
+                // write accumulated sums to smem.
+                if(lane_idx == 0)
+                {
+                    smem[t] = qk_acc;
                 }
             }
+        }
+    }
 
-            // Use shared reduction to compute max and compute softmax on shared memory.
-            // write max acc
-            if(lane_idx == 0)
-            {
-                smem[KV_M_MAX + wavefront_idx] = max_qk_acc;
-            }
-            __syncthreads();
-            if(lane_idx < wavefronts_per_block)
-            {
-                max_qk_acc = ck::math::max(max_qk_acc, smem[KV_M_MAX + lane_idx]);
-            }
-            // shared across all threads in block
-            max_qk_acc = wavefrontReduce(max_qk_acc, [](auto a, auto b) { return a > b ? a : b; });
+    // Use shared reduction to compute max and compute softmax on shared memory.
+    // write max acc
+    if(lane_idx == 0)
+    {
+        smem[KV_M_MAX + wavefront_idx] = max_qk_acc;
+    }
+    __syncthreads();
+    if(lane_idx < wavefronts_per_block)
+    {
+        max_qk_acc = ck::math::max(max_qk_acc, smem[KV_M_MAX + lane_idx]);
+    }
+    // shared across all threads in block
+    max_qk_acc = wavefrontReduce(max_qk_acc, [](auto a, auto b) { return a > b ? a : b; });
 
-            // each wavefront computes partial sum of exp.
-            compute_t softmax_denominator = 0.0f;
-            for(int32_t t = thread_linear_idx; t < t_max; t += threads_per_block)
-            {
-                softmax_denominator += ck::math::exp(smem[t] - max_qk_acc);
-            }
-            softmax_denominator =
-                wavefrontReduce(softmax_denominator, [](auto a, auto b) { return a + b; });
+    // each wavefront computes partial sum of exp.
+    compute_t softmax_denominator = 0.0f;
+    for(int32_t t = thread_linear_idx; t < t_max; t += threads_per_block)
+    {
+        softmax_denominator += ck::math::exp(smem[t] - max_qk_acc);
+    }
+    softmax_denominator =
+        wavefrontReduce(softmax_denominator, [](auto a, auto b) { return a + b; });
 
-            if(lane_idx == 0)
-            {
-                smem[KV_M_MAX + wavefront_idx] = softmax_denominator;
-            }
-            __syncthreads();
+    if(lane_idx == 0)
+    {
+        smem[KV_M_MAX + wavefront_idx] = softmax_denominator;
+    }
+    __syncthreads();
 
-            // now, compute sum of exp(x - max(x)) over all intermediate results.
-            softmax_denominator = 0.0;
-            if(lane_idx < wavefronts_per_block)
-            {
-                softmax_denominator = smem[KV_M_MAX + lane_idx];
-            }
-            softmax_denominator =
-                wavefrontReduce(softmax_denominator, [](auto a, auto b) { return a + b; });
+    // now, compute sum of exp(x - max(x)) over all intermediate results.
+    softmax_denominator = 0.0;
+    if(lane_idx < wavefronts_per_block)
+    {
+        softmax_denominator = smem[KV_M_MAX + lane_idx];
+    }
+    softmax_denominator =
+        wavefrontReduce(softmax_denominator, [](auto a, auto b) { return a + b; });
 
-            const compute_t softmax_scale_factor = 1. / softmax_denominator;
-            // now, compute the normalization across all threads.
-            for(int32_t t = thread_linear_idx; t < t_max; t += threads_per_block)
-            {
-                smem[t] = ck::math::exp(smem[t] - max_qk_acc) * softmax_scale_factor;
-            }
-            __syncthreads();
+    const compute_t softmax_scale_factor = 1. / softmax_denominator;
+    // now, compute the normalization across all threads.
+    for(int32_t t = thread_linear_idx; t < t_max; t += threads_per_block)
+    {
+        smem[t] = ck::math::exp(smem[t] - max_qk_acc) * softmax_scale_factor;
+    }
+    __syncthreads();
 
-            // Split T across wavefronts in a block
-            // each wavefront compute sum(t_subset) P[t] * V[t_subset, d]
-            // outputs are of size float[D]
+    // Split T across wavefronts in a block
+    // each wavefront compute sum(t_subset) P[t] * V[t_subset, d]
+    // outputs are of size float[D]
 
-            compute_t ps[n_loop_unroll] = {};
-            compute_vec_t o_acc         = 0;
-            if(lane_active_for_io)
-            {
-                for(auto tt = wavefront_idx * n_loop_unroll; tt < t_max_unroll; tt += dtt)
-                {
+    compute_t ps[n_loop_unroll] = {};
+    compute_vec_t o_acc         = 0;
+    if(lane_active_for_io)
+    {
+        for(auto tt = wavefront_idx * n_loop_unroll; tt < t_max_unroll; tt += dtt)
+        {
 #pragma unroll n_loop_unroll
-                    for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
-                    {
-                        const int32_t t = tt + ttt;
-                        // load the V[b][t][g][h|0][:] row into registers, reusing K
-                        // register storage
-                        load_v<data_t, data_vec_t>(
-                            cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
-                        ps[ttt] = smem[t];
-                    }
+            for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
+            {
+                const int32_t t = tt + ttt;
+                // load the V[b][t][g][h|0][:] row into registers, reusing K register
+                // storage
+                load_v<data_t, data_vec_t>(cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
+                ps[ttt] = smem[t];
+            }
 
 #pragma unroll n_loop_unroll
-                    for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
-                    {
-                        o_acc = scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
-                    }
-                }
-
-                for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
-                    tt += wavefronts_per_block * n_loop_unroll_tail)
-                {
-#pragma unroll n_loop_unroll_tail
-                    for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-                    {
-                        const int32_t t = tt + ttt;
-                        if(t < t_max)
-                        {
-                            // load the V[b][t][g][h|0][:] row into registers, reusing K
-                            // register storage
-                            load_v<data_t, data_vec_t>(
-                                cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
-                            ps[ttt] = smem[t];
-                        }
-                    }
-
-#pragma unroll n_loop_unroll_tail
-                    for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
-                    {
-                        const int32_t t = tt + ttt;
-                        if(t < t_max)
-                        {
-                            o_acc =
-                                scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
-                        }
-                    }
-                }
-            }
-            // now, each thread has partial sums. Write to smem and get accumulated
-            // results back.
-            __syncthreads();
-
-            // NB: needs sizeof(smem) >= `vec_size` * (sizeof(float)==4) *
-            // threadsPerBlock
-            if(lane_active_for_io)
+            for(auto ttt = 0; ttt < n_loop_unroll; ++ttt)
             {
-                store_v<compute_t, compute_vec_t>(&smem[0], thread_linear_idx, o_acc);
-            }
-
-            __syncthreads();
-            // sum up partial D rows from other wavefronts
-            if(wavefront_idx == 0 && lane_active_for_io)
-            {
-                union
-                {
-                    compute_vec_t vec = 0;
-                    compute_t arr[vec_size];
-                } r;
-                for(int32_t w = 0; w < wavefronts_per_block; ++w)
-                {
-                    compute_vec_t partial_r;
-                    load_v<compute_t, compute_vec_t>(
-                        smem, w * threads_per_wavefront + lane_idx, &partial_r);
-                    r.vec += partial_r;
-                }
-                // elementwise convert from compute_t result to data_t out to be written
-                union
-                {
-                    data_vec_t vec;
-                    data_t arr[vec_size];
-                } bf_r;
-#pragma unroll
-                for(int32_t i = 0; i < vec_size; ++i)
-                {
-                    bf_r.arr[i] = ck::type_convert<data_t>(r.arr[i]);
-                }
-                // write output row O[b][m][g][h][:]
-                data_t* __restrict__ o_ = O + XQO_base_offset;
-                store_v<data_t, data_vec_t>(o_, lane_idx, bf_r.vec);
+                o_acc = scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
             }
         }
 
-    } // namespace
+        for(auto tt = t_max_unroll + wavefront_idx * n_loop_unroll_tail; tt < t_max;
+            tt += wavefronts_per_block * n_loop_unroll_tail)
+        {
+#pragma unroll n_loop_unroll_tail
+            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+            {
+                const int32_t t = tt + ttt;
+                if(t < t_max)
+                {
+                    // load the V[b][t][g][h|0][:] row into registers, reusing K register
+                    // storage
+                    load_v<data_t, data_vec_t>(
+                        cache_V_base + t * K_stride_m, lane_idx, &k_loads[ttt]);
+                    ps[ttt] = smem[t];
+                }
+            }
 
-    namespace ck {
-    namespace tensor_operation {
-    namespace device {
-    template <typename scalar_t>
-    struct FMHADecoderSeqlen1DeviceOp : public BaseOperator
+#pragma unroll n_loop_unroll_tail
+            for(auto ttt = 0; ttt < n_loop_unroll_tail; ++ttt)
+            {
+                const int32_t t = tt + ttt;
+                if(t < t_max)
+                {
+                    o_acc = scalar_scale_acc<data_t, vec_size>(o_acc, k_loads[ttt], ps[ttt]);
+                }
+            }
+        }
+    }
+    // now, each thread has partial sums. Write to smem and get accumulated
+    // results back.
+    __syncthreads();
+
+    // NB: needs sizeof(smem) >= `vec_size` * (sizeof(float)==4) * threadsPerBlock
+    if(lane_active_for_io)
     {
-        using DeviceOp = FMHADecoderSeqlen1DeviceOp;
-        struct Argument : public BaseArgument
+        store_v<compute_t, compute_vec_t>(&smem[0], thread_linear_idx, o_acc);
+    }
+
+    __syncthreads();
+    // sum up partial D rows from other wavefronts
+    if(wavefront_idx == 0 && lane_active_for_io)
+    {
+        union
         {
-            const scalar_t* __restrict__ XQ;
-            const scalar_t* __restrict__ cache_K;
-            const scalar_t* __restrict__ cache_V;
-            scalar_t* __restrict__ O;
-            const int32_t* __restrict__ seq_kv_lens;
-            const ptrdiff_t XQ_stride_b;
-            const ptrdiff_t XQ_stride_m;
-            const ptrdiff_t XQ_stride_g;
-            const ptrdiff_t XQ_stride_h;
-            const ptrdiff_t K_stride_b;
-            const ptrdiff_t K_stride_m;
-            const ptrdiff_t K_stride_g;
-            const ptrdiff_t K_stride_h;
-            const int32_t Q_size_m;
-            const int32_t Q_size_g;
-            const int32_t Q_size_h;
-            const int32_t Q_size_k;
-            const int32_t K_size_m;
-            const bool multiquery;
-            const float qk_scale;
-
-            const dim3 grid_dim;
-            const dim3 block_dim;
-            const size_t lds_bytes;
-
-            Argument(const scalar_t* __restrict__ XQ,
-                     const scalar_t* __restrict__ cache_K,
-                     const scalar_t* __restrict__ cache_V,
-                     scalar_t* __restrict__ O,
-                     const int32_t* __restrict__ seq_kv_lens,
-                     const ptrdiff_t XQ_stride_b,
-                     const ptrdiff_t XQ_stride_m,
-                     const ptrdiff_t XQ_stride_g,
-                     const ptrdiff_t XQ_stride_h,
-                     const ptrdiff_t K_stride_b,
-                     const ptrdiff_t K_stride_m,
-                     const ptrdiff_t K_stride_g,
-                     const ptrdiff_t K_stride_h,
-                     const int32_t Q_size_m,
-                     const int32_t Q_size_g,
-                     const int32_t Q_size_h,
-                     const int32_t Q_size_k,
-                     const int32_t K_size_m,
-                     const bool multiquery,
-                     const float qk_scale,
-                     const dim3 grid_dim,
-                     const dim3 block_dim,
-                     const size_t lds_bytes)
-                : XQ(XQ),
-                  cache_K(cache_K),
-                  cache_V(cache_V),
-                  O(O),
-                  seq_kv_lens(seq_kv_lens),
-                  XQ_stride_b(XQ_stride_b),
-                  XQ_stride_m(XQ_stride_m),
-                  XQ_stride_g(XQ_stride_g),
-                  XQ_stride_h(XQ_stride_h),
-                  K_stride_b(K_stride_b),
-                  K_stride_m(K_stride_m),
-                  K_stride_g(K_stride_g),
-                  K_stride_h(K_stride_h),
-                  Q_size_m(Q_size_m),
-                  Q_size_g(Q_size_g),
-                  Q_size_h(Q_size_h),
-                  Q_size_k(Q_size_k),
-                  K_size_m(K_size_m),
-                  multiquery(multiquery),
-                  qk_scale(qk_scale),
-                  grid_dim(grid_dim),
-                  block_dim(block_dim),
-                  lds_bytes(lds_bytes)
-            {
-            }
-        };
-
-        struct Invoker : public BaseInvoker
+            compute_vec_t vec = 0;
+            compute_t arr[vec_size];
+        } r;
+        for(int32_t w = 0; w < wavefronts_per_block; ++w)
         {
-            using Argument = DeviceOp::Argument;
-            float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
-            {
-                auto threads_per_wavefront = arg.block_dim.x;
+            compute_vec_t partial_r;
+            load_v<compute_t, compute_vec_t>(
+                smem, w * threads_per_wavefront + lane_idx, &partial_r);
+            r.vec += partial_r;
+        }
+        // elementwise convert from compute_t result to data_t out to be written
+        union
+        {
+            data_vec_t vec;
+            data_t arr[vec_size];
+        } bf_r;
+#pragma unroll
+        for(int32_t i = 0; i < vec_size; ++i)
+        {
+            bf_r.arr[i] = ck::type_convert<data_t>(r.arr[i]);
+        }
+        // write output row O[b][m][g][h][:]
+        data_t* __restrict__ o_ = O + XQO_base_offset;
+        store_v<data_t, data_vec_t>(o_, lane_idx, bf_r.vec);
+    }
+}
 
-                auto Q_size_k_alignment_necessary = 0;
+} // namespace
 
-                for(auto vec_size : {4, 2, 1})
-                {
-                    if(arg.Q_size_k <= vec_size * threads_per_wavefront)
-                    {
-                        Q_size_k_alignment_necessary = vec_size;
-                    }
-                };
+namespace ck {
+namespace tensor_operation {
+namespace device {
+template <typename scalar_t>
+struct FMHADecoderSeqlen1DeviceOp : public BaseOperator
+{
+    using DeviceOp = FMHADecoderSeqlen1DeviceOp;
+    struct Argument : public BaseArgument
+    {
+        const scalar_t* __restrict__ XQ;
+        const scalar_t* __restrict__ cache_K;
+        const scalar_t* __restrict__ cache_V;
+        scalar_t* __restrict__ O;
+        const int32_t* __restrict__ seq_kv_lens;
+        const ptrdiff_t XQ_stride_b;
+        const ptrdiff_t XQ_stride_m;
+        const ptrdiff_t XQ_stride_g;
+        const ptrdiff_t XQ_stride_h;
+        const ptrdiff_t K_stride_b;
+        const ptrdiff_t K_stride_m;
+        const ptrdiff_t K_stride_g;
+        const ptrdiff_t K_stride_h;
+        const int32_t Q_size_m;
+        const int32_t Q_size_g;
+        const int32_t Q_size_h;
+        const int32_t Q_size_k;
+        const int32_t K_size_m;
+        const bool multiquery;
+        const float qk_scale;
 
-                if(!Q_size_k_alignment_necessary)
-                {
-                    throw std::runtime_error("Unsupported Q_size_k");
-                }
+        const dim3 grid_dim;
+        const dim3 block_dim;
+        const size_t lds_bytes;
 
-                if(arg.Q_size_k % Q_size_k_alignment_necessary)
-                {
-                    throw std::runtime_error("Unsupported alignment for Q_size_k");
-                }
-
-                return launch_and_time_kernel(
-                    stream_config,
-                    Q_size_k_alignment_necessary == 4
-                        ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 4>
-                    : Q_size_k_alignment_necessary == 2
-                        ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 2>
-                    : Q_size_k_alignment_necessary == 1
-                        ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 1>
-                        : nullptr,
-                    arg.grid_dim,
-                    arg.block_dim,
-                    arg.lds_bytes,
-                    arg.XQ,
-                    arg.cache_K,
-                    arg.cache_V,
-                    arg.O,
-                    arg.seq_kv_lens,
-                    arg.XQ_stride_b,
-                    arg.XQ_stride_m,
-                    arg.XQ_stride_g,
-                    arg.XQ_stride_h,
-                    arg.K_stride_b,
-                    arg.K_stride_m,
-                    arg.K_stride_g,
-                    arg.K_stride_h,
-                    arg.Q_size_m,
-                    arg.Q_size_g,
-                    arg.Q_size_h,
-                    arg.Q_size_k,
-                    arg.K_size_m,
-                    arg.multiquery,
-                    arg.qk_scale);
-            }
-        };
+        Argument(const scalar_t* __restrict__ XQ,
+                 const scalar_t* __restrict__ cache_K,
+                 const scalar_t* __restrict__ cache_V,
+                 scalar_t* __restrict__ O,
+                 const int32_t* __restrict__ seq_kv_lens,
+                 const ptrdiff_t XQ_stride_b,
+                 const ptrdiff_t XQ_stride_m,
+                 const ptrdiff_t XQ_stride_g,
+                 const ptrdiff_t XQ_stride_h,
+                 const ptrdiff_t K_stride_b,
+                 const ptrdiff_t K_stride_m,
+                 const ptrdiff_t K_stride_g,
+                 const ptrdiff_t K_stride_h,
+                 const int32_t Q_size_m,
+                 const int32_t Q_size_g,
+                 const int32_t Q_size_h,
+                 const int32_t Q_size_k,
+                 const int32_t K_size_m,
+                 const bool multiquery,
+                 const float qk_scale,
+                 const dim3 grid_dim,
+                 const dim3 block_dim,
+                 const size_t lds_bytes)
+            : XQ(XQ),
+              cache_K(cache_K),
+              cache_V(cache_V),
+              O(O),
+              seq_kv_lens(seq_kv_lens),
+              XQ_stride_b(XQ_stride_b),
+              XQ_stride_m(XQ_stride_m),
+              XQ_stride_g(XQ_stride_g),
+              XQ_stride_h(XQ_stride_h),
+              K_stride_b(K_stride_b),
+              K_stride_m(K_stride_m),
+              K_stride_g(K_stride_g),
+              K_stride_h(K_stride_h),
+              Q_size_m(Q_size_m),
+              Q_size_g(Q_size_g),
+              Q_size_h(Q_size_h),
+              Q_size_k(Q_size_k),
+              K_size_m(K_size_m),
+              multiquery(multiquery),
+              qk_scale(qk_scale),
+              grid_dim(grid_dim),
+              block_dim(block_dim),
+              lds_bytes(lds_bytes)
+        {
+        }
     };
-    } // namespace device
-    } // namespace tensor_operation
-    } // namespace ck
+
+    struct Invoker : public BaseInvoker
+    {
+        using Argument = DeviceOp::Argument;
+        float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
+        {
+            auto threads_per_wavefront = arg.block_dim.x;
+
+            auto Q_size_k_alignment_necessary = 0;
+
+            for(auto vec_size : {4, 2, 1})
+            {
+                if(arg.Q_size_k <= vec_size * threads_per_wavefront)
+                {
+                    Q_size_k_alignment_necessary = vec_size;
+                }
+            }
+
+            if(!Q_size_k_alignment_necessary)
+            {
+                throw std::runtime_error("Unsupported Q_size_k");
+            }
+
+            if(arg.Q_size_k % Q_size_k_alignment_necessary)
+            {
+                throw std::runtime_error("Unsupported alignment for Q_size_k");
+            }
+
+            return launch_and_time_kernel(
+                stream_config,
+                Q_size_k_alignment_necessary == 4
+                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 4>
+                : Q_size_k_alignment_necessary == 2
+                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 2>
+                : Q_size_k_alignment_necessary == 1
+                    ? efficient_attention_forward_decoder_ck_kernel<scalar_t, 1>
+                    : nullptr,
+                arg.grid_dim,
+                arg.block_dim,
+                arg.lds_bytes,
+                arg.XQ,
+                arg.cache_K,
+                arg.cache_V,
+                arg.O,
+                arg.seq_kv_lens,
+                arg.XQ_stride_b,
+                arg.XQ_stride_m,
+                arg.XQ_stride_g,
+                arg.XQ_stride_h,
+                arg.K_stride_b,
+                arg.K_stride_m,
+                arg.K_stride_g,
+                arg.K_stride_h,
+                arg.Q_size_m,
+                arg.Q_size_g,
+                arg.Q_size_h,
+                arg.Q_size_k,
+                arg.K_size_m,
+                arg.multiquery,
+                arg.qk_scale);
+        }
+    };
+};
+} // namespace device
+} // namespace tensor_operation
+} // namespace ck

--- a/xformers/ops/fmha/ck_decoder.py
+++ b/xformers/ops/fmha/ck_decoder.py
@@ -75,35 +75,35 @@ class FwOp(AttentionFwOpBase):
         if needs_gradient:
             raise NotImplementedError("backward pass is not supported")
         attn_bias = inp.attn_bias
-
+        q, k, v = inp.get_qkv_in_bmghk()
         if attn_bias is not None:
-            attn_bias.k_seqinfo.to(inp.key.device)
-            attn_bias.q_seqinfo.to(inp.query.device)
+            attn_bias.k_seqinfo.to(k.device)
+            attn_bias.q_seqinfo.to(q.device)
             padding = attn_bias.k_seqinfo.padding
             seq_positions_gpu = attn_bias.k_seqinfo.seqlen
         else:
-            padding = inp.key.shape[1]
+            padding = k.shape[1]
             seq_positions_gpu = None
 
         if attn_bias is not None:
-            # key: (1, B * padding, 1 if multiquery else Hkv, D)
+            # key: (1, B * padding, G, 1 if multiquery else Hkv, D)
             # value: like key
-            # query: (1, B * q_seqlen, Hq, D)
-            multiquery = inp.key.stride(2) == 0
+            # query: (1, B * q_seqlen, G, Hq, D)
+            multiquery = k.stride(3) == 0
             if multiquery:
-                key = inp.key[0, :, :1].unflatten(0, (-1, padding))
-                value = inp.value[0, :, :1].unflatten(0, (-1, padding))
+                key = k[0, :, :, :1].unflatten(0, (-1, padding))
+                value = v[0, :, :, :1].unflatten(0, (-1, padding))
             else:
-                key = inp.key[0].unflatten(0, (-1, padding))
-                value = inp.value[0].unflatten(0, (-1, padding))
-            query = inp.query[0].unflatten(0, (key.shape[0], -1))    
+                key = k[0].unflatten(0, (-1, padding))
+                value = v[0].unflatten(0, (-1, padding))
+            query = q[0].unflatten(0, (key.shape[0], -1))    
         else:
-            # key: (B, padding, 1 if multiquery else Hkv, D)
+            # key: (B, padding, G, 1 if multiquery else Hkv, D)
             # value: like key
-            # query: (B, q_seqlen, Hq, D)
-            key = inp.key
-            query = inp.query
-            value = inp.value
+            # query: (B, q_seqlen, G, Hq, D)
+            key = k
+            query = q
+            value = v
 
         if inp.scale is not None:
             qk_scale = inp.scale

--- a/xformers/ops/fmha/ck_decoder.py
+++ b/xformers/ops/fmha/ck_decoder.py
@@ -27,10 +27,6 @@ class FwOp(AttentionFwOpBase):
 
         attn_bias = d.attn_bias
         if isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
-            # If we don't get here, we've an error elsewhere
-            if d.query.ndim != 4 or d.key.ndim != 4:
-                reasons.append("Inputs must be BMHK. BMK not supported")
-
             if d.query.shape[0] != 1:
                 reasons.append(f"One formal batch element expected; got {d.query.shape[0]}")
 

--- a/xformers/ops/fmha/common.py
+++ b/xformers/ops/fmha/common.py
@@ -3,9 +3,10 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+from functools import partial
 import math
 from dataclasses import dataclass
-from typing import Any, List, Mapping, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, List, Mapping, Optional, Set, Tuple, Type, Union
 
 import torch
 
@@ -26,6 +27,17 @@ def _is_bias_type_supported_in_BMK(attn_bias_type: Any) -> bool:
     if attn_bias_type in [LowerTriangularMask, torch.Tensor]:
         return True
     return False
+
+
+def _attn_bias_apply(
+    attn_bias: Optional[Union[torch.Tensor, AttentionBias]],
+    op: Callable[[torch.Tensor], torch.Tensor],
+) -> Optional[Union[torch.Tensor, AttentionBias]]:
+    if isinstance(attn_bias, torch.Tensor):
+        return op(attn_bias)
+    if isinstance(attn_bias, LowerTriangularMaskWithTensorBias):
+        return LowerTriangularMaskWithTensorBias(op(attn_bias._bias))
+    return attn_bias
 
 
 @dataclass
@@ -49,14 +61,34 @@ class Inputs:
     def scale_float(self) -> float:
         return self.query.shape[-1] ** (-0.5) if self.scale is None else self.scale
 
+    def get_qkv_in_bmghk(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.query.ndim == 5:
+            return self.query, self.key, self.value
+        if self.query.ndim == 4:
+            return (
+                self.query.unsqueeze(2),
+                self.key.unsqueeze(2),
+                self.value.unsqueeze(2),
+            )
+        if self.value.ndim == 3:
+            return (
+                self.query[:, :, None, None],
+                self.key[:, :, None, None],
+                self.value[:, :, None, None],
+            )
+        assert False
+
     def normalize_bmhk(self) -> Tuple[int, ...]:
-        if self.query.ndim not in [3, 4]:
+        if self.query.ndim not in [3, 4, 5]:
             raise ValueError(
                 f"Invalid shape for query: {self.query.shape}. "
-                "Expected shape [batch, seqlen, num_heads, K], or [batch, seqlen, K]."
+                "Expected shape [batch, seqlen, head_groups, num_heads_per_group, K]"
+                ", [batch, seqlen, num_heads, K], or [batch, seqlen, K]."
             )
         if self.value.dtype == torch.int32:
-            # Quantized K/V case, in which the last dims of Q and K/V are different
+            # Quantized K/V case, in which the last dims of Q and K are different.
+            # NB we currently don't have any implementations for quantized KV with
+            # SUPPORTS_DIFFERENT_VALUE_EMBED.
             output_shape = tuple(self.query.shape)
         else:
             output_shape = (self.query.shape[:-1]) + (self.value.shape[-1],)
@@ -65,12 +97,9 @@ class Inputs:
             self.query = self.query.unsqueeze(2)
             self.key = self.key.unsqueeze(2)
             self.value = self.value.unsqueeze(2)
-            if isinstance(self.attn_bias, torch.Tensor):
-                if self.attn_bias.ndim != 3:
-                    raise ValueError(
-                        f"Expected BMK format for attn_bias, but got {self.attn_bias.shape}"
-                    )
-                self.attn_bias = self.attn_bias.unsqueeze(1)
+            self.attn_bias = _attn_bias_apply(
+                self.attn_bias, partial(torch.unsqueeze, dim=1)
+            )
         return output_shape
 
     def validate_inputs(self) -> None:

--- a/xformers/ops/fmha/common.py
+++ b/xformers/ops/fmha/common.py
@@ -104,9 +104,11 @@ class Inputs:
 
     def validate_inputs(self) -> None:
         qkv = (self.query, self.key, self.value)
-        if self.query.ndim not in (3, 4) or any(x.ndim != self.query.ndim for x in qkv):
+        if self.query.ndim not in (3, 4, 5) or any(
+            x.ndim != self.query.ndim for x in qkv
+        ):
             raise ValueError(
-                f"Query/Key/Value should all have BMHK or BMK shape.\n"
+                f"Query/Key/Value should all have BMGHK, BMHK or BMK shape.\n"
                 f"  query.shape: {self.query.shape}\n"
                 f"  key.shape  : {self.key.shape}\n"
                 f"  value.shape: {self.value.shape}"


### PR DESCRIPTION
As titled. Now we can run `benchmark_attn_decoding` from upstream with `Hkv=2` which enables GQA mode of the kernel (G > 1). The results on mi250:

```
[---------------------------------------- flash_decodingfw ---------------------------------------]
                                             |  pytorch  |  optimized[ck]  |  optimized[ck-decoder]
1 threads: ----------------------------------------------------------------------------------------
      B=256 Mq=1 Mkv=256 Hq=16 Hkv=1 K=128   |   5861.0  |      1563.5      |          502.1        
      B=256 Mq=1 Mkv=256 Hq=16 Hkv=2 K=128   |   7727.7  |         N/A⁺     |          517.4        
      B=128 Mq=1 Mkv=512 Hq=16 Hkv=1 K=128   |   4389.0  |      1456.2      |          415.2        
      B=128 Mq=1 Mkv=512 Hq=16 Hkv=2 K=128   |   6372.9  |         N/A⁺     |          419.6        
      B=64 Mq=1 Mkv=1024 Hq=16 Hkv=1 K=128   |   4523.6  |      1471.1      |          370.5        
      B=64 Mq=1 Mkv=1024 Hq=16 Hkv=2 K=128   |   6502.5  |         N/A⁺     |          376.7        
      B=32 Mq=1 Mkv=2048 Hq=16 Hkv=1 K=128   |   4338.5  |      1447.0      |          349.5        
      B=32 Mq=1 Mkv=2048 Hq=16 Hkv=2 K=128   |   6211.2  |         N/A⁺     |          348.4        
      B=16 Mq=1 Mkv=4096 Hq=16 Hkv=1 K=128   |   4968.6  |      1699.3      |          397.6        
      B=16 Mq=1 Mkv=4096 Hq=16 Hkv=2 K=128   |   6819.6  |         N/A⁺     |          395.9        
      B=8 Mq=1 Mkv=8192 Hq=16 Hkv=1 K=128    |   4464.9  |      2252.3      |          507.1        
      B=8 Mq=1 Mkv=8192 Hq=16 Hkv=2 K=128    |   6408.4  |         N/A⁺     |          510.8        
      B=4 Mq=1 Mkv=16384 Hq=16 Hkv=1 K=128   |   4433.4  |      2260.6      |          N/A⁺⁺        
      B=4 Mq=1 Mkv=16384 Hq=16 Hkv=2 K=128   |   6182.9  |         N/A⁺     |          N/A⁺⁺        
      B=2 Mq=1 Mkv=32768 Hq=16 Hkv=1 K=128   |   4566.5  |      4502.2      |          N/A⁺⁺        
      B=2 Mq=1 Mkv=32768 Hq=16 Hkv=2 K=128   |   6245.1  |         N/A⁺     |          N/A⁺⁺        
      B=1 Mq=1 Mkv=65536 Hq=16 Hkv=1 K=128   |   1919.0  |      8749.6      |          N/A⁺⁺        
      B=1 Mq=1 Mkv=65536 Hq=16 Hkv=2 K=128   |   3435.0  |         N/A⁺     |          N/A⁺⁺        
      B=1 Mq=1 Mkv=131072 Hq=16 Hkv=1 K=128  |   3807.2  |     17539.4      |          N/A⁺⁺        
      B=1 Mq=1 Mkv=131072 Hq=16 Hkv=2 K=128  |   6839.7  |         N/A⁺     |          N/A⁺⁺        

Times are in microseconds (us).

⁺ rank-5 inputs need to be supported 
⁺⁺ context lengths > 8192 are not supported in the decoder kernel
```

Tests:

```
======================================================================================== short test summary info ========================================================================================
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-16--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-16-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-16-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-32--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-32-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-1-32-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-8-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-8-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-8-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-4-8--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-4-8-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-32-4-8-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-16--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-16-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-16-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-32--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-32-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-1-32-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-8-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-8-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-8-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-4-8--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-4-8-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f16-4096-4-8-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-16--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-16-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-16-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-32--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-32-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-1-32-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-8-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-8-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-8-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-4-8--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-4-8-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-32-4-8-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-16--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-16-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-16-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-32--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-32-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-1-32-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-8-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-8-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-8-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-4-8--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-4-8-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[bf16-4096-4-8-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-16--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-16-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-16-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-32--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-32-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-1-32-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-8-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-8-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-8-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-4-8--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-4-8-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-32-4-8-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-16--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-16-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-16-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-32--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-32-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-1-32-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-8-1--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-8-1-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-8-1-gqa2-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-4-8--FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-4-8-mq-FwOp]
PASSED ../xformers/tests/test_mem_eff_attention_ck.py::test_decoder[f32-4096-4-8-gqa2-FwOp]
========================================================================================== 90 passed in 2.38s ===========================================================================================
```