### PR TITLE
Add Triton Flash Attention 2 forward op

### DIFF
--- a/tests/test_mem_eff_attention.py
+++ b/tests/test_mem_eff_attention.py
@@ -1295,6 +1295,8 @@ def test_grad_checkpointing(
         k,
         kv,
     ) = opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv
+    if op is fmha.triton.FwOp:
+        pytest.skip("Triton Flash Attention 2 doesn't support backward pass yet")
     bias_type = None
     opFW_device_dtype_biasT_B_Mq_Mkv_H_K_Kv = (
         op,

--- a/xformers/benchmarks/benchmark_mem_eff_attention.py
+++ b/xformers/benchmarks/benchmark_mem_eff_attention.py
@@ -122,12 +122,21 @@ SHAPES = [
     ),
 ]
 
+
+class TritonFlashAttentionFwAutotuned(xformers.ops.fmha.triton.FwOp):
+    AUTOTUNE = True
+
+
 OPS = [
     (xformers.ops.fmha.cutlass.FwOp, xformers.ops.fmha.cutlass.BwOp),
     (xformers.ops.fmha.flash.FwOp, xformers.ops.fmha.flash.BwOp),
-    # TODO: Triton is not stable: it can trigger Illegal Memory Accesses
-    # and its performance varies a lot between runs.
-    # (xformers.ops.fmha.triton.FwOp, xformers.ops.fmha.triton.BwOp),
+    (xformers.ops.fmha.ck.FwOp, xformers.ops.fmha.ck.BwOp),
+    (
+        TritonFlashAttentionFwAutotuned,
+        xformers.ops.fmha.cutlass.BwOp
+        if torch.version.cuda
+        else xformers.ops.fmha.ck.BwOp,
+    ),
 ]
 
 

--- a/xformers/benchmarks/utils.py
+++ b/xformers/benchmarks/utils.py
@@ -557,7 +557,7 @@ def benchmark_run_and_compare(
             # pbar.write(f"Skipped (NotImplementedError)")
             continue
         except RuntimeError as e:
-            if "CUDA out of memory" not in str(e):
+            if not _is_oom_error(e):
                 raise
             if not quiet:
                 pbar.write("Skipped (OOM)")
@@ -602,7 +602,7 @@ def benchmark_run_and_compare(
                     memory = torch.cuda.max_memory_allocated() / 2**20 - mem_begin
                     measurement.mem_use = memory
                 except RuntimeError as e:
-                    if "CUDA out of memory" not in str(e):
+                    if not _is_oom_error(e):
                         raise
                     if not quiet:
                         pbar.write("Skipped (OOM)")
@@ -611,7 +611,7 @@ def benchmark_run_and_compare(
                 if not quiet:
                     pbar.write(f"{name}: memory used: {memory} MB")
         except RuntimeError as e:
-            if "CUDA out of memory" not in str(e):
+            if not _is_oom_error(e):
                 raise
             if not quiet:
                 pbar.write("Skipped (OOM)")
@@ -652,6 +652,8 @@ def benchmark_run_and_compare(
             results, reference=results_compare_to, atol_s=atol_s, rtol=rtol
         )
 
+def _is_oom_error(e):
+    return isinstance(e, (torch.cuda.OutOfMemoryError, triton.runtime.autotuner.OutOfResources))
 
 def _fail_if_regressions(
     results: List[Any], reference: List[Any], atol_s: float, rtol: float

--- a/xformers/ops/common.py
+++ b/xformers/ops/common.py
@@ -34,7 +34,8 @@ class BaseOperator:
 
     @classmethod
     def is_available(cls) -> bool:
-        if cls.OPERATOR is None or cls.OPERATOR.__name__ == "no_such_operator":
+        # cls.OPERATOR can be either a kernel or a Triton Autotuner object, which doesn't have __name__
+        if cls.OPERATOR is None or getattr(cls.OPERATOR, "__name__", "") == "no_such_operator":
             return False
         return True
 

--- a/xformers/ops/fmha/__init__.py
+++ b/xformers/ops/fmha/__init__.py
@@ -28,8 +28,8 @@ MemoryEfficientAttentionDecoderOp = (decoder.FwOp, cutlass.BwOp)
 MemoryEfficientAttentionTritonFwdFlashBwOp = (triton.FwOp, flash.BwOp)
 MemoryEfficientAttentionFlashAttentionOp = (flash.FwOp, flash.BwOp)
 MemoryEfficientAttentionOp = (small_k.FwOp, small_k.BwOp)
-TritonFlashAttentionOp = (triton.FwOp, triton.BwOp)
-MemoryEfficientAttentionCkOp = (ck.FwOp, ck.BwOp) 
+TritonFlashAttentionOp = (triton.FwOp, cutlass.BwOp if torch.version.cuda else ck.BwOp)
+MemoryEfficientAttentionCkOp = (ck.FwOp, ck.BwOp)
 MemoryEfficientAttentionCkDecoderOp = (ck_decoder.FwOp, ck.BwOp)
 
 class _fMHA(torch.autograd.Function):
@@ -395,7 +395,6 @@ ALL_FW_OPS: Sequence[Type[AttentionFwOpBase]] = [
 ALL_BW_OPS: Sequence[Type[AttentionBwOpBase]] = [
     cutlass.BwOp,
     flash.BwOp,
-    triton.BwOp,
     small_k.BwOp,
 ]
 

--- a/xformers/ops/fmha/ck.py
+++ b/xformers/ops/fmha/ck.py
@@ -29,7 +29,7 @@ from .common import (
 )
 
 def _minimum_gemm_alignment(inp: Inputs) -> int:
-    return 1 
+    return 1
 
 
 def _get_seqlen_info(
@@ -86,6 +86,20 @@ Example: use `attn_bias = torch.zeros([1, 1, 5, 8])[:,:,:,:5]` instead of `torch
                 "you should call `.contiguous()` on the bias"
             )
 
+def _check_large_shapes(reasons: List[str], inp: Inputs) -> None:
+    """CK kernel throws "Memory access fault by GPU node-2" when B * T >= 2**20, might be some index overflow.
+    To reproduce, remove this function and run benchmark_mem_eff_attention with ParlAI model shape (256, 4096, 16, 64).
+    This needs further debugging, for now let's not support such shapes.
+    """
+    b_t_limit = 1024 ** 2
+    q_too_large = inp.query.shape[0] *  inp.query.shape[1] >= b_t_limit
+    k_too_large = inp.key.shape[0] *  inp.key.shape[1] >= b_t_limit
+    v_too_large = inp.value.shape[0] *  inp.value.shape[1] >= b_t_limit
+    if q_too_large or k_too_large or v_too_large:
+        reasons.append(
+            "Input is too large: product of first two dimensions of q/k/v must be < 2**20"
+        )
+
 
 class _CustomMaskType(int, Enum):
     """
@@ -120,7 +134,7 @@ def _custom_mask_type(bias: Optional[Union[torch.Tensor, AttentionBias]]) -> int
 @register_operator
 class FwOp(AttentionFwOpBase):
     """xFormers' MHA kernel based on Composable Kernel.
-    Supports AMD MI 200 and MI 300 GPUs 
+    Supports AMD MI 200 and MI 300 GPUs
     """
 
     OPERATOR = get_xformers_operator("efficient_attention_forward_ck")
@@ -205,6 +219,7 @@ class FwOp(AttentionFwOpBase):
         check_lastdim_alignment_stride1(reasons, "query", d.query, matmul_alignment_mn)
         check_lastdim_alignment_stride1(reasons, "value", d.value, matmul_alignment_mn)
         _check_bias_alignment(reasons, d.attn_bias)
+        _check_large_shapes(reasons, d)
         return reasons
 
     @classmethod
@@ -299,6 +314,7 @@ class BwOp(AttentionBwOpBase):
                     f"(shape: {tuple(attn_bias_tensor.shape)}"
                     f"/ expected: {expected_bias_shape})"
                 )
+        _check_large_shapes(reasons, d)
         return reasons
 
     @classmethod
@@ -328,7 +344,7 @@ class BwOp(AttentionBwOpBase):
             attn_bias=_get_tensor_bias(inp.attn_bias),
             seqstart_q=seqstart_q,
             seqstart_k=seqstart_k,
-            max_seqlen_q=max_seqlen_q, 
+            max_seqlen_q=max_seqlen_q,
             seqlen_k=inp.attn_bias.k_seqinfo.seqlen_cpu
             if isinstance(inp.attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask)
             else None,

--- a/xformers/ops/fmha/triton.py
+++ b/xformers/ops/fmha/triton.py
@@ -13,7 +13,7 @@ https://github.com/ROCmSoftwarePlatform/triton/blob/670ae8054da008424097989a5b6e
 """
 
 from dataclasses import replace
-from typing import Any, List, Optional, Set, Tuple
+from typing import Any, List, Mapping, Optional, Set, Tuple
 
 import torch
 

--- a/xformers/ops/fmha/triton.py
+++ b/xformers/ops/fmha/triton.py
@@ -3,63 +3,432 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+"""
+Triton Flash Attention 2
+Based on
+https://github.com/openai/triton/blob/293b7fd592a1602f2305c1bd0bc978bbd97337d6/python/tutorials/06-fused-attention.py  # noqa: E501
+https://github.com/openai/triton/blob/293b7fd592a1602f2305c1bd0bc978bbd97337d6/python/triton/ops/flash_attention.py  # noqa: E501
+https://github.com/Dao-AILab/flash-attention/blob/dd9a6fa45a9b90ff954d2b3f3f44241b9216190e/flash_attn/flash_attn_triton.py  # noqa: E501
+https://github.com/ROCmSoftwarePlatform/triton/blob/670ae8054da008424097989a5b6e3816aa601e07/python/perf-kernels/06-fused-attention-transV.py  # noqa: E501
+"""
 
 from dataclasses import replace
-from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple
+from typing import Any, List, Optional, Set, Tuple
 
 import torch
 
-from ... import _is_triton_available
+import triton
+import triton.language as tl
+
 from ..common import register_operator
 
-# This implementation needs pre-MLIR triton
-# The BW pass is not stable/well tested
-# And also does not have the latest improvements
-if TYPE_CHECKING or (False and _is_triton_available()):
-    try:
-        from flash_attn.flash_attn_triton import (
-            _flash_attn_backward,
-            _flash_attn_forward,
-        )
-    except ImportError:
-        import importlib
-        import pathlib
-        import sys
-        import types
-
-        def import_module_from_path(path: str) -> types.ModuleType:
-            """Import a module from the given path, w/o __init__.py"""
-            module_path = pathlib.Path(path).resolve()
-            module_name = module_path.stem  # 'path/x.py' -> 'x'
-            spec = importlib.util.spec_from_file_location(module_name, module_path)  # type: ignore
-            assert isinstance(spec, importlib.machinery.ModuleSpec)
-            module = importlib.util.module_from_spec(spec)  # type: ignore
-            sys.modules[module_name] = module
-            assert isinstance(spec.loader, importlib.abc.Loader)
-            spec.loader.exec_module(module)
-            return module
-
-        flash_attn = import_module_from_path(
-            "third_party/flash-attention/flash_attn/flash_attn_triton.py"
-        )
-        _flash_attn_backward = flash_attn._flash_attn_backward
-        _flash_attn_forward = flash_attn._flash_attn_forward
-
-    triton_flash_backward = _flash_attn_backward
-    triton_flash_forward = _flash_attn_forward
-else:
-    triton_flash_backward = None
-    triton_flash_forward = None
-
-from .attn_bias import LowerTriangularMask
-from .common import (
-    AttentionBwOpBase,
-    AttentionFwOpBase,
-    Context,
-    Gradients,
-    Inputs,
-    check_lastdim_alignment_stride1,
+from .attn_bias import (
+    BlockDiagonalCausalMask,
+    BlockDiagonalCausalWithOffsetPaddedKeysMask,
+    LowerTriangularMask,
 )
+from .common import AttentionFwOpBase, check_lastdim_alignment_stride1, Context, Inputs
+
+
+@triton.jit
+def _fwd_kernel_triton_flash_inner(
+    acc,
+    l_i,
+    m_i,
+    q,
+    K_block_ptr,
+    V_block_ptr,
+    q_seq_start,
+    lo,
+    hi,
+    start_m,
+    qk_scale,
+    kv_len,
+    offs_m,
+    offs_n,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    CAST_BEFORE_MATMUL: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    STAGE: tl.constexpr,
+    pre_load_v: tl.constexpr,
+):
+    BOUNDS_CHECKS_STAGE: tl.constexpr = BOUNDS_CHECKS_N and STAGE == 2
+    # Doesn't seem to make a difference
+    if STAGE == 1:
+        lo = 0
+    else:
+        lo = tl.multiple_of(lo, BLOCK_N)
+        K_block_ptr = tl.advance(K_block_ptr, (0, lo))
+        V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
+
+    # loop over k, v and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)  # doesn't seem to make a difference
+        # -- load k, v --
+        k = tl.load(K_block_ptr, boundary_check=(1,) if BOUNDS_CHECKS_STAGE else ())
+        # Moving masking here seems to introduce num errors,
+        # e.g. in test_forward[tritonflashattF-cuda-torch.bfloat16-NoneType-1-256-15-1-32-32-False-BMHK]
+        # if BOUNDS_CHECKS_N or USE_SEQ_LEN:
+        #     k = tl.where(hi - tl.arange(0, BLOCK_N) > start_n, k, float("-inf"))
+        if pre_load_v:
+            v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_STAGE else ())
+        # -- compute qk ---
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        qk += tl.dot(q.to(k.dtype), k, allow_tf32=ALLOW_TF32) * qk_scale
+        if CAST_BEFORE_MATMUL:
+            k = k.to(tl.float32)
+        if STAGE == 2:
+            if IS_CAUSAL:
+                # For some reason this is faster than start_n <= q_seq_start + offs_m[:, None] - offs_n[None, :]
+                qk = tl.where(
+                    q_seq_start + offs_m[:, None] >= (start_n + offs_n[None, :]),
+                    qk,
+                    float("-inf"),
+                )
+            if BOUNDS_CHECKS_N:
+                qk = tl.where(tl.arange(0, BLOCK_N) < hi - start_n, qk, float("-inf"))
+
+        # -- compute scaling constant ---
+        m_i_new = tl.maximum(m_i, tl.max(qk, 1))
+        qk = qk - m_i_new[:, None]
+        alpha = tl.math.exp2(m_i - m_i_new)
+        p = tl.math.exp2(qk)
+
+        # -- scale and update acc --
+        acc *= alpha[:, None]
+        if not pre_load_v:
+            v = tl.load(V_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_STAGE else ())
+        if CAST_BEFORE_MATMUL:
+            v = v.to(tl.float32)
+        acc += tl.dot(p.to(v.dtype), v, allow_tf32=ALLOW_TF32)
+        # -- update m_i and l_i --
+        l_i = l_i * alpha + tl.sum(p, 1)
+        m_i = m_i_new
+        # update pointers
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+    return acc, l_i, m_i
+
+
+@triton.jit
+def _fwd_kernel_triton_flash(
+    Q,
+    K,
+    V,
+    sm_scale,
+    L,
+    Out,
+    Seq_len,
+    Seq_pos_q,
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,
+    stride_vz,
+    stride_vh,
+    stride_vk,
+    stride_vn,
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_on,
+    Z,
+    H,
+    N_CTX,
+    Mkv,
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    BOUNDS_CHECKS_N: tl.constexpr,
+    BOUNDS_CHECKS_M: tl.constexpr,
+    ALLOW_TF32: tl.constexpr,
+    CAST_BEFORE_MATMUL: tl.constexpr,
+    USE_SEQ_LEN_KV: tl.constexpr,
+    USE_SEQ_POS_Q: tl.constexpr,
+    IS_KV_PADDED: tl.constexpr,  # Switch between padded and non-padded block-diagonal causal masks
+    pre_load_v: tl.constexpr,  # TODO: understand if that matters
+):
+    start_m = tl.program_id(0).to(tl.int64)
+    off_hz = tl.program_id(1).to(tl.int64)
+
+    tl.static_assert((IS_KV_PADDED and USE_SEQ_POS_Q) or not IS_KV_PADDED)
+
+    off_z = off_hz // H
+    off_h = off_hz % H
+    if USE_SEQ_POS_Q:
+        seqpos = tl.load(Seq_pos_q + off_z)
+        seqpos_next = tl.load(Seq_pos_q + off_z + 1)
+        q_len = seqpos_next - seqpos
+        q_offset = seqpos * stride_qm + off_h * stride_qh
+        out_offset = seqpos * stride_om + off_h * stride_oh
+        if not IS_KV_PADDED:
+            # BlockDiagonalCausalMask, no padding, use same sequence positions as for Q
+            kv_offset = seqpos * stride_kn + off_h * stride_kh
+            kv_len = q_len
+            q_seq_start = 0
+        else:
+            # BlockDiagonalCausalWithOffsetPaddedKeysMask
+            kv_offset = off_z * stride_kz + off_h * stride_kh
+            if USE_SEQ_LEN_KV:
+                kv_len = tl.load(Seq_len + off_z)
+                q_seq_start = kv_len - q_len
+            else:
+                # if no variable K/V seqlens are provided, assume full length
+                kv_len = Mkv
+                q_seq_start = 0
+    else:
+        # No mask or simple causal mask
+        q_len = N_CTX
+        q_offset = off_z * stride_qz + off_h * stride_qh
+        out_offset = off_z * stride_oz + off_h * stride_oh
+
+        kv_len = Mkv
+        q_seq_start = 0
+        kv_offset = off_z * stride_kz + off_h * stride_kh
+
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q + q_offset,
+        shape=(q_len, BLOCK_DMODEL),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0),
+    )
+    K_block_ptr = tl.make_block_ptr(
+        base=K + kv_offset,
+        shape=(BLOCK_DMODEL, kv_len),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, 0),
+        block_shape=(BLOCK_DMODEL, BLOCK_N),
+        order=(0, 1),
+    )
+    V_block_ptr = tl.make_block_ptr(
+        base=V + kv_offset,
+        shape=(kv_len, BLOCK_DMODEL),
+        strides=(stride_vk, stride_vn),
+        offsets=(0, 0),
+        block_shape=(BLOCK_N, BLOCK_DMODEL),
+        order=(0, 1),
+    )
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)  # For Q
+    offs_n = tl.arange(0, BLOCK_N)  # For K/V
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    # scale sm_scale by log_2(e) and use
+    # 2^x instead of exp in the loop because CSE and LICM
+    # don't work as expected with `exp` in the loop
+    qk_scale = sm_scale * 1.44269504
+    # load q: it will stay in SRAM throughout on NV GPUs but in VGPRs on AMD GPUs
+    q = tl.load(
+        Q_block_ptr, boundary_check=(0,) if BOUNDS_CHECKS_M or USE_SEQ_POS_Q else ()
+    )
+
+    # The loop over K/V sequence blocks is divided into two stages:
+    # Stage 1: (many) blocks which don't need boundary conditions checks - not touching sequence end or diagonal
+    # Stage 2: (few) blocks which need boundary conditions checks
+    # Following https://github.com/openai/triton/blob/293b7fd592a1602f2305c1bd0bc978bbd97337d6/python/tutorials/06-fused-attention.py  # noqa: E501
+
+    """
+    Iteration doesn't need masking if
+        - 1) block doesn't cross the diagonal: max(kv_pos) <= min(q_pos)
+        - 2) block doesn't cross the end of the sequence: max(kv_pos) < kv_len
+    Find maximum start_n for which condition 1 is satisifed.
+    Remember that
+        q_pos = q_seq_start + offs_m[:, None]
+        kv_pos = start_n + offs_n[None, :]
+        offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = tl.arange(0, BLOCK_N)
+    min(q_pos) = q_seq_start + start_m * BLOCK_M
+    max(kv_pos) = start_n + BLOCK_N - 1
+    So the condition becomes
+        q_seq_start + start_m * BLOCK_M >= start_n + BLOCK_N - 1
+    So:
+    1) start_n <= q_seq_start + start_m * BLOCK_M - BLOCK_N + 1
+    2) start_n <= kv_len - BLOCK_N
+
+    So the last allowed start_n without masking is min(q_seq_start + start_m * BLOCK_M + 1, kv_len) - BLOCK_N
+    """
+    # Second stage can only be skipped if no mask is used and K/V length is divisible by the tile size
+    TWO_STAGES: tl.constexpr = BOUNDS_CHECKS_N or (
+        IS_CAUSAL or (USE_SEQ_LEN_KV or (USE_SEQ_POS_Q and not IS_KV_PADDED))
+    )
+    if TWO_STAGES:
+        # Border between two stages
+        hi_stage_1 = min(q_seq_start + start_m * BLOCK_M + 1, kv_len) - BLOCK_N
+        hi_stage_1 = (
+            hi_stage_1 // BLOCK_N
+        ) * BLOCK_N  # Don't understand why it doesn't work without this
+    else:
+        hi_stage_1 = kv_len
+
+    # Stage 1 - no boundary conditions
+    acc, l_i, m_i = _fwd_kernel_triton_flash_inner(
+        acc,
+        l_i,
+        m_i,
+        q,
+        K_block_ptr,
+        V_block_ptr,
+        q_seq_start,
+        0,
+        hi_stage_1,
+        start_m,
+        qk_scale,
+        kv_len,
+        offs_m,
+        offs_n,
+        BLOCK_M,
+        BLOCK_N,
+        IS_CAUSAL,
+        BOUNDS_CHECKS_N,
+        CAST_BEFORE_MATMUL,
+        ALLOW_TF32,
+        STAGE=1,
+        pre_load_v=pre_load_v,
+    )
+    if TWO_STAGES:
+        hi = (
+            tl.minimum(kv_len, q_seq_start + (start_m + 1) * BLOCK_M)
+            if IS_CAUSAL
+            else kv_len
+        )
+        # Do we need this barrier?
+        # tl.debug_barrier()
+        # Stage 2 - with boundary conditions
+        acc, l_i, m_i = _fwd_kernel_triton_flash_inner(
+            acc,
+            l_i,
+            m_i,
+            q,
+            K_block_ptr,
+            V_block_ptr,
+            q_seq_start,
+            hi_stage_1,
+            hi,
+            start_m,
+            qk_scale,
+            kv_len,
+            offs_m,
+            offs_n,
+            BLOCK_M,
+            BLOCK_N,
+            IS_CAUSAL,
+            BOUNDS_CHECKS_N,
+            CAST_BEFORE_MATMUL,
+            ALLOW_TF32,
+            STAGE=2,
+            pre_load_v=pre_load_v,
+        )
+
+    # write back l and m
+    acc1 = acc / l_i[:, None]
+    l_ptrs = L + off_hz * N_CTX + offs_m
+    # Save LSE, converting from log2 to natural logarithm
+    l_mask = (
+        start_m * BLOCK_M + tl.arange(0, BLOCK_M) < q_len if BOUNDS_CHECKS_M else None
+    )
+    tl.store(l_ptrs, (m_i + tl.math.log2(l_i)) / 1.44269504, mask=l_mask)
+    # write back O
+    O_block_ptr = tl.make_block_ptr(
+        base=Out + out_offset,
+        shape=(q_len, BLOCK_DMODEL),
+        strides=(stride_om, stride_on),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0),
+    )
+    tl.store(
+        O_block_ptr,
+        acc1.to(Out.dtype.element_ty),
+        boundary_check=(0,) if BOUNDS_CHECKS_M or USE_SEQ_POS_Q else (),
+    )
+
+
+_autotuner_config_amd_full = [
+    triton.Config(
+        {"BLOCK_M": 256, "BLOCK_N": 64, "waves_per_eu": 2, "pre_load_v": False},
+        num_stages=1,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_M": 128, "BLOCK_N": 128, "waves_per_eu": 2, "pre_load_v": False},
+        num_stages=1,
+        num_warps=4,
+    ),
+    triton.Config(
+        {"BLOCK_M": 256, "BLOCK_N": 128, "waves_per_eu": 2, "pre_load_v": False},
+        num_stages=1,
+        num_warps=8,
+    ),
+    triton.Config(
+        {"BLOCK_M": 128, "BLOCK_N": 64, "waves_per_eu": 3, "pre_load_v": True},
+        num_stages=1,
+        num_warps=4,
+    ),  # d64-False
+    triton.Config(
+        {"BLOCK_M": 128, "BLOCK_N": 64, "waves_per_eu": 3, "pre_load_v": False},
+        num_stages=1,
+        num_warps=4,
+    ),  # d64-True
+]
+
+
+_autotuner_config_amd_dummy = [
+    triton.Config(
+        {"BLOCK_M": 128, "BLOCK_N": 64, "waves_per_eu": 2, "pre_load_v": False},
+        num_stages=1,
+        num_warps=8,
+    ),
+]
+
+_autotuner_config_nvidia_dummy = [
+    triton.Config(
+        {"BLOCK_M": 128, "BLOCK_N": 64, "pre_load_v": False},
+        num_stages=1,
+        num_warps=8,
+    ),
+]
+
+
+def autotune_kernel(kernel, autotune):
+
+    kernel = triton.heuristics(
+        values={
+            "BOUNDS_CHECKS_N": lambda args: ((args["Mkv"] % args["BLOCK_N"]) != 0)
+            or (args["USE_SEQ_POS_Q"] and not args["IS_KV_PADDED"]),
+            "BOUNDS_CHECKS_M": lambda args: (args["N_CTX"] % args["BLOCK_M"]) != 0,
+        }
+    )(kernel)
+
+    if torch.version.cuda:
+        configs = _autotuner_config_nvidia_dummy
+    elif autotune:
+        configs = _autotuner_config_amd_full
+    else:
+        configs = _autotuner_config_amd_dummy
+
+    kernel = triton.autotune(
+        configs=configs,
+        key=["Z", "H", "N_CTX", "IS_CAUSAL", "BLOCK_DMODEL"],
+    )(kernel)
+    return kernel
+
+
+_fwd_kernel_triton_flash_maybe_autotuned = {
+    True: autotune_kernel(_fwd_kernel_triton_flash, True),
+    False: autotune_kernel(_fwd_kernel_triton_flash, False),
+}
 
 
 def _prepare_inputs(inp: Inputs) -> Inputs:
@@ -85,7 +454,7 @@ class FwOp(AttentionFwOpBase):
         `Phil Tillet's code <https://github.com/openai/triton/blob/master/python/tutorials/06-fused-attention.py>`_
     """
 
-    OPERATOR = triton_flash_forward
+    OPERATOR = _fwd_kernel_triton_flash
     SUPPORTED_DEVICES = {"cuda"}
     CUDA_MINIMUM_COMPUTE_CAPABILITY = (8, 0)
     SUPPORTED_DTYPES = {torch.half, torch.bfloat16}
@@ -93,12 +462,35 @@ class FwOp(AttentionFwOpBase):
     SUPPORTED_ATTN_BIAS_TYPES: Set[Any] = {
         type(None),
         LowerTriangularMask,
-        # TODO: backwards accuracy is failing for a few cases, perhaps we want to disable this for now.
-        # torch.Tensor,
+        BlockDiagonalCausalMask,
+        BlockDiagonalCausalWithOffsetPaddedKeysMask,
     }
     SUPPORTS_DROPOUT = False
     SUPPORTS_CUSTOM_SCALE = True
     NAME = "tritonflashattF"
+
+    # Off by default to avoid slowing down tests.
+    # Needs to be turned on explicitly in benchmarks, in prod, and in a small number of tests
+    AUTOTUNE = False
+
+    ERROR_ATOL: Mapping[torch.dtype, float] = {
+        torch.half: 2e-2,
+        torch.bfloat16: 2e-2,
+    }
+
+    ERROR_RTOL: Mapping[torch.dtype, float] = {
+        torch.half: 2e-2,
+        torch.bfloat16: 2e-2,
+    }
+
+    @classmethod
+    def shape_not_supported_reasons(
+        cls, Mq: int, Mkv: int, K: int, Kv: int
+    ) -> List[str]:
+        reasons = super().shape_not_supported_reasons(Mq, Mkv, K, Kv)
+        if K not in {32, 64, 128}:
+            reasons.append(f"Embed dim {K} not supported")
+        return reasons
 
     @classmethod
     def not_supported_reasons(cls, d: Inputs) -> List[str]:
@@ -106,20 +498,52 @@ class FwOp(AttentionFwOpBase):
         check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
         check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
         check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
-        if cls.OPERATOR is None:
-            reasons.append("triton is not available")
-        if d.device.type == "cuda":
+
+        if isinstance(
+            d.attn_bias,
+            BlockDiagonalCausalWithOffsetPaddedKeysMask,
+        ):
+            # Support padded causal block-diagonal mask if the distance between each two consecutive key starts
+            # is equal to the padding (key lengths can vary)
+            batch_size = len(d.attn_bias.q_seqinfo.seqstart_py) - 1
+            B_T = d.key.shape[
+                1
+            ]  # For these mask types the shapes of Q/K/V are (1, B_T, H, K)
+            if B_T % batch_size:
+                reasons.append(
+                    f"K/V should be padded, but batch size {batch_size} doesn't divide B*T={B_T}"
+                )
+            else:
+                kv_maxlen = d.attn_bias.k_seqinfo.padding
+                for i, seqstart in enumerate(d.attn_bias.k_seqinfo.seqstart_py):
+                    if seqstart != i * kv_maxlen:
+                        reasons.append(
+                            "Variable K/V start positions are not supported, they should be determined "
+                            f"by kv_maxlen/padding: {d.attn_bias.k_seqinfo.seqstart_py=} {kv_maxlen=} {batch_size=}"
+                        )
+                        break
+        if isinstance(
+            d.attn_bias,
+            BlockDiagonalCausalMask,
+        ):
+            # Support padded causal block-diagonal mask if for each batch element number of queries is equal
+            # to the number of key/values, i.e. each block is square
+            for q_pos, kv_pos in zip(
+                d.attn_bias.q_seqinfo.seqstart_py, d.attn_bias.k_seqinfo.seqstart_py
+            ):
+                if q_pos != kv_pos:
+                    reasons.append(
+                        f"Position starts of Q and K/V should be the same, but got {q_pos} != {kv_pos}"
+                        f"{d.attn_bias.q_seqinfo.seqstart_py=}, {d.attn_bias.k_seqinfo.seqstart_py=}"
+                    )
+
+        if d.device.type == "cuda" and torch.version.cuda:
             # Has only been tested on 8.0 / 9.0.
             # Fails on 7.5 with illegal memory access
             if torch.cuda.get_device_capability(d.device) < (8, 0):
                 reasons.append(
                     "requires GPU with sm80 minimum compute capacity, e.g., A100/H100/L4"
                 )
-        if _is_triton_available():
-            import triton
-
-            if triton.__version__ > "2.0.0":
-                reasons.append("Only work on pre-MLIR triton for now")
         return reasons
 
     @classmethod
@@ -127,75 +551,98 @@ class FwOp(AttentionFwOpBase):
         cls, inp: Inputs, needs_gradient: bool
     ) -> Tuple[torch.Tensor, Optional[Context]]:
         inp = _prepare_inputs(inp)
+        attn_bias = inp.attn_bias
+        seq_len_kv = None
+        seqstart_q = None
 
-        out, lse, softmax_scale = triton_flash_forward(
-            q=inp.query,
-            k=inp.key,
-            v=inp.value,
-            bias=inp.attn_bias if isinstance(inp.attn_bias, torch.Tensor) else None,
-            softmax_scale=inp.scale_float,
-            causal=isinstance(inp.attn_bias, LowerTriangularMask),
+        q = inp.query
+        k = inp.key
+        v = inp.value
+
+        is_bt_h_m = isinstance(
+            attn_bias,
+            (BlockDiagonalCausalWithOffsetPaddedKeysMask, BlockDiagonalCausalMask),
         )
-        return out, Context(lse=lse, out=out)
+        if is_bt_h_m:
+            # q ~ [1, B*T, H, K]
+            # TODO: do we really need to do this cast? seems fishy but
+            # I just copied it from the split-k kernel
+            attn_bias.k_seqinfo.to(inp.query.device)
+            attn_bias.q_seqinfo.to(inp.query.device)
+            seqstart_q = attn_bias.q_seqinfo.seqstart
+            B = len(seqstart_q) - 1
+            H, Kq = inp.query.shape[-2:]
+            H2, Kkv = inp.key.shape[-2:]
 
+            Mq = attn_bias.q_seqinfo.max_seqlen
+            if isinstance(attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask):
+                seq_len_kv = attn_bias.k_seqinfo.seqlen
+                # assume kv has been padded
+                k = k.reshape(B, -1, H2, Kkv)
+                v = v.reshape(B, -1, H2, Kkv)
+        else:
+            B, Mq, H, _ = q.shape
 
-@register_operator
-class BwOp(AttentionBwOpBase):
-    __doc__ = FwOp.__doc__
+        # Coded for BHMK format
+        q, k, v = (
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+        )
 
-    OPERATOR = triton_flash_backward
-    SUPPORTED_DEVICES = FwOp.SUPPORTED_DEVICES
-    CUDA_MINIMUM_COMPUTE_CAPABILITY = FwOp.CUDA_MINIMUM_COMPUTE_CAPABILITY
-    SUPPORTED_DTYPES = FwOp.SUPPORTED_DTYPES
-    SUPPORTED_MAX_K = FwOp.SUPPORTED_MAX_K
-    SUPPORTED_ATTN_BIAS_TYPES = FwOp.SUPPORTED_ATTN_BIAS_TYPES
-    SUPPORTS_DROPOUT = FwOp.SUPPORTS_DROPOUT
-    SUPPORTS_CUSTOM_SCALE = FwOp.SUPPORTS_CUSTOM_SCALE
-    SUPPORTS_DIFFERENT_VALUE_EMBED = FwOp.SUPPORTS_DIFFERENT_VALUE_EMBED
-    NAME = "tritonflashattB"
+        out = torch.empty_like(q)
 
-    @classmethod
-    def not_supported_reasons(cls, d: Inputs) -> List[str]:
-        reasons = super(BwOp, cls).not_supported_reasons(d)
-        check_lastdim_alignment_stride1(reasons, "query", d.query, 8)
-        check_lastdim_alignment_stride1(reasons, "key", d.key, 8)
-        check_lastdim_alignment_stride1(reasons, "value", d.value, 8)
-        if cls.OPERATOR is None:
-            reasons.append("triton is not available")
-        if d.device.type == "cuda":
-            if torch.cuda.get_device_capability(d.device) != (8, 0):
-                reasons.append("requires A100 GPU")
-        if _is_triton_available():
-            import triton
+        _, _, Mkv, K = k.shape
 
-            if triton.__version__ > "2.0.0":
-                reasons.append("Only work on pre-MLIR triton for now")
-        return reasons
+        sm_scale = K**-0.5 if inp.scale is None else inp.scale
+        L = torch.empty((B * H, Mq), device=q.device, dtype=torch.float32)
+        is_causal = inp.attn_bias is not None
+        use_seq_len_kv = seq_len_kv is not None
+        use_seq_pos_q = seqstart_q is not None
+        is_kv_padded = isinstance(
+            attn_bias, BlockDiagonalCausalWithOffsetPaddedKeysMask
+        )
 
-    @classmethod
-    def apply(cls, ctx: Context, inp: Inputs, grad: torch.Tensor) -> Gradients:
-        inp = _prepare_inputs(inp)
+        grid = lambda META: (triton.cdiv(Mq, META["BLOCK_M"]), B * H, 1)  # noqa: E731
+        kernel = _fwd_kernel_triton_flash_maybe_autotuned[cls.AUTOTUNE]
+        kernel[grid](
+            q,
+            k,
+            v,
+            sm_scale,
+            L,
+            out,
+            seq_len_kv,
+            seqstart_q,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            out.stride(3),
+            B,
+            H,
+            Mq,
+            Mkv,
+            BLOCK_DMODEL=K,
+            IS_CAUSAL=is_causal,
+            USE_SEQ_LEN_KV=use_seq_len_kv,
+            USE_SEQ_POS_Q=use_seq_pos_q,
+            IS_KV_PADDED=is_kv_padded,
+            ALLOW_TF32=torch.backends.cuda.matmul.allow_tf32,
+            CAST_BEFORE_MATMUL=False,
+        )
 
-        # Triton's autotune causes the Tensor._version to change, and so Pytorch autograd
-        # does a memcpy. To avoid this we run in inference_mode, which doesn't track the version.
-        with torch.inference_mode():
-            grads = Gradients(
-                dq=torch.empty_like(inp.query),
-                dk=torch.empty_like(inp.key),
-                dv=torch.empty_like(inp.value),
-            )
-            cls.OPERATOR(
-                grad,
-                inp.query,
-                inp.key,
-                inp.value,
-                ctx.out,
-                ctx.get_padded_lse(128),
-                grads.dq,
-                grads.dk,
-                grads.dv,
-                bias=inp.attn_bias if isinstance(inp.attn_bias, torch.Tensor) else None,
-                softmax_scale=inp.scale_float,
-                causal=isinstance(inp.attn_bias, LowerTriangularMask),
-            )
-        return grads
+        out = out.transpose(1, 2)
+        L = L.reshape(B, H, Mq)
+        return out, Context(lse=L, out=out)


### PR DESCRIPTION
Add an implementation of Triton Flash Attention 2 forward op supporting causal, block-diagonal causal, and padded block-diagonal causal masks. This op can be used in the prefill phase of LLM inference.

This implementation is based on a combination of the sources below. Block-diagonal mask support is new.

- https://github.com/openai/triton/blob/293b7fd592a1602f2305c1bd0bc978bbd97337d6/python/tutorials/06-fused-attention.py
- https://github.com/openai/triton/blob/293b7fd592a1602f2305c1bd0bc978bbd97337d6/python/triton/ops/flash_attention.py 
- https://github.com/Dao-AILab/flash-attention/blob/dd9a6fa45a9b90ff954d2b3f3f44241b9216190e/flash_attn/flash_attn_triton.py
- https://github.com/ROCmSoftwarePlatform/triton/blob/670ae8054da008424097989a5b6e3816aa601e07/python/perf-kernels/06-fused-attention-transV.py


Note this PR removes the backwards op, which was disabled anyway. Once we have a working version of backwards, we can add it separately.


# Tests

```
pytest tests/test_mem_eff_attention.py -vvv -k tritonflashattF

============== 455 passed, 704 skipped, 748 deselected in 19.90s ===============
```
https://gist.github.com/sgrigory/28c80629b61e06398fec514cc96e0508

# Benchmarks
For LLaMA shapes, with local changes to skip backward and only select these specific shapes
```
python xformers/benchmarks/benchmark_mem_eff_attention.py --omit-baselines 2>&1 | tee log.txt
```
```

[------------------ attention (attn_bias=<class 'NoneType'>) -----------------]
                                                |    ckF     |  tritonflashattF
1 threads: --------------------------------------------------------------------
      f16 1-2048-8-128, p=0.0, BiasT=NoneType   |     444.2  |         452.8   
      f16 1-8192-8-128, p=0.0, BiasT=NoneType   |    4426.4  |        3300.5   
      f16 4-2048-8-128, p=0.0, BiasT=NoneType   |    1164.6  |        1051.0   
      f16 4-8192-8-128, p=0.0, BiasT=NoneType   |   17686.3  |       11054.4   
      f16 8-2048-8-128, p=0.0, BiasT=NoneType   |    2313.8  |        1663.9   
      f16 8-8192-8-128, p=0.0, BiasT=NoneType   |   35602.5  |       22058.0   
      f16 16-2048-8-128, p=0.0, BiasT=NoneType  |    4596.5  |        3135.7   
      f16 16-8192-8-128, p=0.0, BiasT=NoneType  |   70172.1  |       43762.1   
      f16 32-2048-8-128, p=0.0, BiasT=NoneType  |    9195.3  |        6083.3   
      f16 32-8192-8-128, p=0.0, BiasT=NoneType  |  140831.0  |       86260.1   
      f16 64-2048-8-128, p=0.0, BiasT=NoneType  |   18120.0  |       11918.9   
      f16 64-8192-8-128, p=0.0, BiasT=NoneType  |  282569.4  |      173456.5   

Times are in microseconds (us).

[--- attention (attn_bias=<class 'xformers.ops.fmha.attn_bias.LowerTriangularMask'>) ----]
                                                           |    ckF     |  tritonflashattF
1 threads: -------------------------------------------------------------------------------
      f16 1-2048-8-128, p=0.0, BiasT=LowerTriangularMask   |     343.2  |         469.0   
      f16 1-8192-8-128, p=0.0, BiasT=LowerTriangularMask   |    2885.9  |        2342.6   
      f16 4-2048-8-128, p=0.0, BiasT=LowerTriangularMask   |     904.6  |         992.3   
      f16 4-8192-8-128, p=0.0, BiasT=LowerTriangularMask   |   10576.2  |        7546.5   
      f16 8-2048-8-128, p=0.0, BiasT=LowerTriangularMask   |    1768.0  |        1649.5   
      f16 8-8192-8-128, p=0.0, BiasT=LowerTriangularMask   |   20953.3  |       14452.8   
      f16 16-2048-8-128, p=0.0, BiasT=LowerTriangularMask  |    3490.1  |        3121.2   
      f16 16-8192-8-128, p=0.0, BiasT=LowerTriangularMask  |   41596.6  |       28055.4   
      f16 32-2048-8-128, p=0.0, BiasT=LowerTriangularMask  |    6919.4  |        6059.5   
      f16 32-8192-8-128, p=0.0, BiasT=LowerTriangularMask  |   82730.5  |       55212.8   
      f16 64-2048-8-128, p=0.0, BiasT=LowerTriangularMask  |   14051.8  |       12036.7   
      f16 64-8192-8-128, p=0.0, BiasT=LowerTriangularMask  |  166060.1  |      110122.3   

Times are in microseconds (us).
```

Note that this benchmark doesn't support multiquery and assumes that q/k/v are in "packed" layout. It also doesn't support block-diagonal masks supported by CK and Triton FA2 kernels. After the update from upstream https://github.com/ROCmSoftwarePlatform/xformers/pull/5 is merged these features should become available I think