### PR TITLE
re-enable multiple wavefronts per threadgroup in ck split-k decoder

### DIFF
--- a/xformers/benchmarks/benchmark_attn_decoding.py
+++ b/xformers/benchmarks/benchmark_attn_decoding.py
@@ -108,6 +108,10 @@ class AttentionDecodingSplitKV(AttentionDecodingFlashDecoding):
     OP = xops.fmha.triton_splitk.FwOp
 
 
+class AttentionDecodingCKSplitKV(AttentionDecodingFlashDecoding):
+    OP = xops.fmha.forward_splitk.FwOp
+ 
+
 class AttentionDecodingPyTorchRepeat(AttentionDecodingFlashDecoding):
     def fw(self) -> None:
         B, Mq, Mkv, Hq, Hkv, K = self.shapes
@@ -125,6 +129,7 @@ BENCHMARKS = {
     "ck-decoder": AttentionDecodingCKDecoder,
     "flash-decoding": AttentionDecodingFlashDecoding,
     "triton_splitK": AttentionDecodingSplitKV,
+    "ck_splitK": AttentionDecodingCKSplitKV,
 }
 
 

--- a/xformers/csrc/attention/hip_fmha/attention_forward_splitk.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_splitk.cpp
@@ -8,7 +8,7 @@
 
 namespace {
 constexpr int32_t kThreadsPerWavefront = 64;
-constexpr int32_t kWavefrontsPerBlock  = 1;
+constexpr int32_t kWavefrontsPerBlock  = 8;
 constexpr int32_t K_MAX                = 4 * kThreadsPerWavefront;
 } // namespace
 

--- a/xformers/csrc/attention/hip_fmha/attention_forward_splitk.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_splitk.cpp
@@ -8,7 +8,7 @@
 
 namespace {
 constexpr int32_t kThreadsPerWavefront = 64;
-constexpr int32_t kWavefrontsPerBlock  = 8;
+constexpr int32_t kWavefrontsPerBlock  = 16;
 constexpr int32_t K_MAX                = 4 * kThreadsPerWavefront;
 } // namespace
 
@@ -72,7 +72,7 @@ at::Tensor& efficient_attention_forward_decoder_splitk_ck_out_impl(
 
     TORCH_CHECK(!seq_kv_lens || seq_kv_lens->is_cuda());
 
-    TORCH_CHECK(cache_K.size(1) <= KV_M_MAX);
+    TORCH_CHECK(cache_K.size(1) / split_k <= KV_M_MAX);
     TORCH_CHECK(cache_K.size(4) <= K_MAX);
 
     constexpr auto rank = 5;

--- a/xformers/csrc/attention/hip_fmha/attention_forward_splitk.cpp
+++ b/xformers/csrc/attention/hip_fmha/attention_forward_splitk.cpp
@@ -503,12 +503,7 @@ struct FMHADecoderSplitAttentionDeviceOp : public BaseOperator
         using Argument = DeviceOp::Argument;
         float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
         {
-
-            // std::cout << arg.str() << std::endl << "stream_id: " << stream_config.stream_id_ <<
-            // std::endl;
-
             auto threads_per_wavefront = arg.block_dim.x;
-
             auto Q_size_k_alignment_necessary = 0;
 
             for(auto vec_size : {4, 2, 1})
@@ -673,10 +668,6 @@ struct FMHADecoderSplitReduceDeviceOp : public BaseOperator
         float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
         {
             auto threads_per_wavefront = arg.block_dim.x;
-
-            // std::cout << arg.str() << std::endl << "stream_id: " << stream_config.stream_id_ <<
-            // std::endl;
-
             auto O_size_k_alignment_necessary = 0;
 
             for(auto vec_size : {4, 2, 1})
@@ -955,10 +946,6 @@ test_split_attention(int32_t padding, int32_t batch_size, int32_t Hq, int32_t Hk
     auto O_percent_mismatch = percent_mismatch(O_ref, O_hip);
     auto m_percent_mismatch = percent_mismatch(m_ref, m_hip);
     auto l_percent_mismatch = percent_mismatch(l_ref, l_hip);
-
-    // if (m_percent_mismatch > 0) {
-    //     std::cout << "ref: " << m_ref << std::endl << "hip: " << m_hip << std::endl;
-    // }
 
     printf("[Test split attention] Padding=%d BS=%d Hq=%d Hkv=%d split_k=%d Mismatched split_O "
            "elements percentage: %.2f Mismatched split_max elements percentage: %.2f Mismatched "

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
@@ -356,7 +356,7 @@ efficient_attention_forward_decoder_splitk_ck_kernel(const scalar_t* __restrict_
 
     // each wavefront computes partial sum of exp.
     compute_t softmax_denominator = 0.0f;
-    for(int32_t t = tt_low + thread_linear_idx; t < tt_tail_high; t += threads_per_block)
+    for(int32_t t = n_unrolled_loops * dtt * split_idx + thread_linear_idx; t < tt_tail_high; t += threads_per_block)
     {
         softmax_denominator += ck::math::exp(smem[t - n_unrolled_loops * dtt * split_idx] - max_qk_acc);
     }
@@ -384,7 +384,7 @@ efficient_attention_forward_decoder_splitk_ck_kernel(const scalar_t* __restrict_
     }
 
     // now, compute the normalization across all threads.
-    for(int32_t t = tt_low + thread_linear_idx; t < tt_tail_high; t += threads_per_block)
+    for(int32_t t = n_unrolled_loops * dtt * split_idx + thread_linear_idx; t < tt_tail_high; t += threads_per_block)
     {
         // softmax scale by sumexp will happen in the reduction kernel
         smem[t - n_unrolled_loops * dtt * split_idx] = ck::math::exp(smem[t - n_unrolled_loops * dtt * split_idx] - max_qk_acc);

--- a/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
+++ b/xformers/csrc/attention/hip_fmha/ck_attention_forward_decoder_splitk.h
@@ -628,11 +628,7 @@ struct FMHADecoderSplitKDeviceOp : public BaseOperator
         using Argument = DeviceOp::Argument;
         float Run(const Argument& arg, const StreamConfig& stream_config = StreamConfig{})
         {
-            // std::cout << arg.str() << std::endl << "stream_id: " << stream_config.stream_id_ <<
-            // std::endl;
-
             auto threads_per_wavefront = arg.block_dim.x;
-
             auto Q_size_k_alignment_necessary = 0;
 
             for(auto vec_size : {4, 2, 1})


### PR DESCRIPTION
Enablement of multiple wavefronts per threadgroup optimization.

(set `kWavefrontsPerBlock = 16`  in a meantime)

```
# pytest /xformers/tests/test_mem_eff_attention_ck.py::test_splitk_decoder

==================================================================================== 36 passed in 3.47s ====================================================================================
```

```
# cmake /xformers/xformers/csrc/attention/hip_fmha/ \
>        -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc \
>        -D CMAKE_PREFIX_PATH=/opt/rocm \
>        -D CMAKE_BUILD_TYPE=Debug \
>        -D GPU_TARGETS="native" && make -j
[100%] Built target attention_forward_splitk_decoder_main
# ./attention_forward_splitk_decoder_main
[Test e2e split-k decoder] Padding=32 BS=1 Hq=16 Hkv=16 split_k=1 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=1 Hq=16 Hkv=16 split_k=2 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=1 Hq=16 Hkv=16 split_k=4 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=1 Hq=16 Hkv=16 split_k=8 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=1 Hq=16 Hkv=16 split_k=16 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=8 Hq=16 Hkv=16 split_k=1 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=8 Hq=16 Hkv=16 split_k=2 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=8 Hq=16 Hkv=16 split_k=4 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=8 Hq=16 Hkv=16 split_k=8 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=32 BS=8 Hq=16 Hkv=16 split_k=16 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=1 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=2 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=4 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=8 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=16 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=1 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=2 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=4 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=8 Mismatched elements percentage: 0.00
[Test e2e split-k decoder] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=16 Mismatched elements percentage: 0.00
[Test split attention] Padding=32 BS=1 Hq=16 Hkv=16 split_k=1 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=1 Hq=16 Hkv=16 split_k=2 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=1 Hq=16 Hkv=16 split_k=4 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=1 Hq=16 Hkv=16 split_k=8 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=1 Hq=16 Hkv=16 split_k=16 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=8 Hq=16 Hkv=16 split_k=1 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=8 Hq=16 Hkv=16 split_k=2 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=8 Hq=16 Hkv=16 split_k=4 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=8 Hq=16 Hkv=16 split_k=8 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=32 BS=8 Hq=16 Hkv=16 split_k=16 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=1 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=2 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=4 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=8 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=16 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=1 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=2 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=4 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=8 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split attention] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=16 Mismatched split_O elements percentage: 0.00 Mismatched split_max elements percentage: 0.00 Mismatched split_sumexp elements percentage: 0.00
[Test split reduce] Padding=32 BS=1 Hq=16 Hkv=16 split_k=1 Mismatched elements percentage: 0.00 
[Test split reduce] Padding=32 BS=1 Hq=16 Hkv=16 split_k=2 Mismatched elements percentage: 0.00 
[Test split reduce] Padding=32 BS=8 Hq=16 Hkv=16 split_k=1 Mismatched elements percentage: 0.00 
[Test split reduce] Padding=32 BS=8 Hq=16 Hkv=16 split_k=2 Mismatched elements percentage: 0.00 
[Test split reduce] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=1 Mismatched elements percentage: 0.00 
[Test split reduce] Padding=4096 BS=1 Hq=16 Hkv=16 split_k=2 Mismatched elements percentage: 0.00 
[Test split reduce] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=1 Mismatched elements percentage: 0.00 
[Test split reduce] Padding=4096 BS=8 Hq=16 Hkv=16 split_k=2 Mismatched elements percentage: 0.00 
```

benchmark_attn_decoding:
```
[---------------------------------------------------------------------------------- attn_decodingfw -----------------------------------------------------] 
                                             |  pytorch  |  optimized[ck]  |  optimized[ck-decoder]  |  optimized[triton_splitK]  |  optimized[ck_splitK]
1 threads: -----------------------------------------------------------------------------------------------------------------------------------------------
      B=256 Mq=1 Mkv=256 Hq=16 Hkv=1 K=128   |   1473.6  |       396.9     |          175.5          |            70.3            |         227.8   
      B=256 Mq=1 Mkv=256 Hq=16 Hkv=2 K=128   |   2404.3  |       556.8     |          189.8          |            75.1            |         238.4   
      B=128 Mq=1 Mkv=512 Hq=16 Hkv=1 K=128   |   1482.1  |       346.5     |          154.0          |            65.7            |         207.4               
      B=128 Mq=1 Mkv=512 Hq=16 Hkv=2 K=128   |   2429.4  |       543.3     |          173.0          |            74.9            |         225.9   
      B=64 Mq=1 Mkv=1024 Hq=16 Hkv=1 K=128   |   1479.7  |       357.4     |          157.7          |            65.1            |         204.6   
      B=64 Mq=1 Mkv=1024 Hq=16 Hkv=2 K=128   |   2390.8  |       497.4     |          177.2          |            75.6            |         226.4       
      B=32 Mq=1 Mkv=2048 Hq=16 Hkv=1 K=128   |   1402.6  |       345.8     |          148.4          |            61.9            |         205.5   
      B=32 Mq=1 Mkv=2048 Hq=16 Hkv=2 K=128   |   2285.7  |       485.4     |          175.7          |            76.0            |         241.2   
      B=16 Mq=1 Mkv=4096 Hq=16 Hkv=1 K=128   |   1389.3  |       334.3     |          145.0          |            69.9            |         229.6     
      B=16 Mq=1 Mkv=4096 Hq=16 Hkv=2 K=128   |   2229.7  |       667.2     |          173.0          |            90.4            |         404.4   
      B=8 Mq=1 Mkv=8192 Hq=16 Hkv=1 K=128    |   1336.5  |       536.8     |          216.9          |            76.2            |         585.7   
      B=8 Mq=1 Mkv=8192 Hq=16 Hkv=2 K=128    |   2189.6  |      1142.8     |          233.8          |            84.1            |         606.3   
      B=4 Mq=1 Mkv=16384 Hq=16 Hkv=1 K=128   |   1677.0  |       991.3     |            N/A          |            73.3            |         229.6   
      B=4 Mq=1 Mkv=16384 Hq=16 Hkv=2 K=128   |   2518.1  |      2130.9     |            N/A          |            78.2            |         246.5   
      B=2 Mq=1 Mkv=32768 Hq=16 Hkv=1 K=128   |   2200.4  |      1922.7     |            N/A          |            74.7            |         204.7   
      B=2 Mq=1 Mkv=32768 Hq=16 Hkv=2 K=128   |   3588.2  |      4132.9     |            N/A          |            84.6            |         223.3   
      B=1 Mq=1 Mkv=65536 Hq=16 Hkv=1 K=128   |    633.8  |      3798.0     |            N/A          |            91.1            |         199.6   
      B=1 Mq=1 Mkv=65536 Hq=16 Hkv=2 K=128   |   1221.1  |      8143.9     |            N/A          |            98.4            |         225.0   
      B=1 Mq=1 Mkv=131072 Hq=16 Hkv=1 K=128  |   1187.5  |      7555.5     |            N/A          |           141.3            |         314.3   
      B=1 Mq=1 Mkv=131072 Hq=16 Hkv=2 K=128  |   2259.4  |     16222.9     |            N/A          |           146.6            |         358.5   
```